### PR TITLE
Add Tiny Shakespeare data loader and 10M demo

### DIFF
--- a/ironcortex/__init__.py
+++ b/ironcortex/__init__.py
@@ -1,5 +1,14 @@
-from .config import CortexConfig
-from .model import CortexReasoner
-from .training import LossWeights, train_step
-from .generation import generate
-from .wiring import hex_neighbors_grid, hex_axial_coords_from_grid
+from .config import CortexConfig as CortexConfig
+from .model import CortexReasoner as CortexReasoner
+from .training import LossWeights as LossWeights, train_step as train_step
+from .generation import generate as generate
+from .wiring import (
+    hex_neighbors_grid as hex_neighbors_grid,
+    hex_axial_coords_from_grid as hex_axial_coords_from_grid,
+)
+from .data import (
+    download_tiny_shakespeare as download_tiny_shakespeare,
+    load_tiny_shakespeare as load_tiny_shakespeare,
+    TextDiffusionDataset as TextDiffusionDataset,
+    TextDiffusionSample as TextDiffusionSample,
+)

--- a/ironcortex/data.py
+++ b/ironcortex/data.py
@@ -1,0 +1,89 @@
+"""Data loading utilities for text datasets and diffusion experiments.
+
+This module currently provides helpers for downloading and preparing the
+Tiny Shakespeare corpus as well as a simple text diffusion dataset that
+emits (noisy, clean, t) triplets for denoising objectives.
+"""
+
+from __future__ import annotations
+
+import os
+import urllib.request
+from dataclasses import dataclass
+
+import torch
+from torch.utils.data import Dataset
+
+TINY_SHAKESPEARE_URL = "https://raw.githubusercontent.com/karpathy/char-rnn/master/data/tinyshakespeare/input.txt"
+
+
+def download_tiny_shakespeare(root: str) -> str:
+    """Ensure the Tiny Shakespeare dataset exists under ``root``.
+
+    Parameters
+    ----------
+    root: str
+        Directory where the dataset should live.
+
+    Returns
+    -------
+    str
+        Path to the downloaded text file.
+    """
+
+    os.makedirs(root, exist_ok=True)
+    out_path = os.path.join(root, "tiny_shakespeare.txt")
+    if not os.path.exists(out_path):
+        urllib.request.urlretrieve(TINY_SHAKESPEARE_URL, out_path)
+    return out_path
+
+
+def load_tiny_shakespeare(root: str) -> torch.Tensor:
+    """Return the Tiny Shakespeare corpus tokenized as bytes.
+
+    The dataset is downloaded on demand if missing.
+    """
+
+    path = download_tiny_shakespeare(root)
+    with open(path, "r", encoding="utf-8") as f:
+        data = f.read()
+    tokens = torch.tensor(list(data.encode("utf-8")), dtype=torch.long)
+    return tokens
+
+
+@dataclass
+class TextDiffusionSample:
+    noisy: torch.Tensor
+    clean: torch.Tensor
+    t: float
+
+
+class TextDiffusionDataset(Dataset):
+    """Simple text diffusion dataset.
+
+    Each item is a tuple ``(noisy, clean, t)`` where ``noisy`` is produced by
+    randomly replacing tokens with probability ``t``.
+    """
+
+    def __init__(self, tokens: torch.Tensor, seq_len: int, vocab_size: int = 256):
+        if tokens.dim() != 1:
+            raise ValueError("tokens must be a 1-D tensor")
+        self.tokens = tokens
+        self.seq_len = seq_len
+        self.vocab_size = vocab_size
+        self.num_seqs = len(tokens) // seq_len
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return self.num_seqs
+
+    def __getitem__(self, idx: int) -> TextDiffusionSample:
+        start = idx * self.seq_len
+        clean = self.tokens[start : start + self.seq_len]
+        t = torch.rand(()).item()
+        mask = torch.rand(self.seq_len) < t
+        noisy = clean.clone()
+        if mask.any():
+            noisy[mask] = torch.randint(
+                0, self.vocab_size, (int(mask.sum()),), dtype=torch.long
+            )
+        return TextDiffusionSample(noisy=noisy, clean=clean, t=t)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,29 @@
+import os
+import urllib.request
+
+import torch
+
+from ironcortex.data import download_tiny_shakespeare, TextDiffusionDataset
+
+
+def test_download_tiny_shakespeare(tmp_path, monkeypatch):
+    fake_content = b"hello"
+
+    def fake_retrieve(url, filename):
+        with open(filename, "wb") as f:
+            f.write(fake_content)
+
+    monkeypatch.setattr(urllib.request, "urlretrieve", fake_retrieve)
+    path = download_tiny_shakespeare(tmp_path)
+    assert os.path.exists(path)
+    with open(path, "rb") as f:
+        assert f.read() == fake_content
+
+
+def test_text_diffusion_dataset():
+    tokens = torch.arange(0, 100, dtype=torch.long)
+    ds = TextDiffusionDataset(tokens, seq_len=10, vocab_size=256)
+    sample = ds[0]
+    assert sample.noisy.shape == (10,)
+    assert sample.clean.shape == (10,)
+    assert 0.0 <= sample.t <= 1.0

--- a/train_tiny_shakespeare.py
+++ b/train_tiny_shakespeare.py
@@ -1,0 +1,51 @@
+import random
+import torch
+
+from ironcortex import (
+    CortexConfig,
+    CortexReasoner,
+    LossWeights,
+    train_step,
+    load_tiny_shakespeare,
+    hex_neighbors_grid,
+    hex_axial_coords_from_grid,
+)
+
+
+def build_model(device: torch.device) -> CortexReasoner:
+    cfg = CortexConfig(R=32, d=256, V=256, K_inner=8, B_br=2, k_active=8, max_T=512)
+    side = int(cfg.R**0.5)
+    neighbors = hex_neighbors_grid(cfg.R, side)
+    reg_coords = hex_axial_coords_from_grid(cfg.R, side)
+    io_idxs = {"sensor": 0, "motor": cfg.R - 1}
+    model = CortexReasoner(neighbors, reg_coords, io_idxs, cfg).to(device)
+    return model
+
+
+def main() -> None:
+    torch.manual_seed(0)
+    random.seed(0)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    tokens = load_tiny_shakespeare("data")
+    seq_len = 256
+    n_seq = len(tokens) // seq_len
+    tokens = tokens[: n_seq * seq_len].view(n_seq, seq_len)
+    loader = torch.utils.data.DataLoader(tokens, batch_size=8, shuffle=True)
+
+    model = build_model(device)
+    n_params = sum(p.numel() for p in model.parameters())
+    print(f"model parameters: {n_params/1e6:.2f}M")
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
+    lamb = LossWeights()
+
+    for step, batch in enumerate(loader, 1):
+        batch = batch.to(device)
+        metrics = train_step(model, optimizer, batch, lamb, device)
+        if step % 10 == 0:
+            print(f"step {step}: loss={metrics['total']:.3f}")
+        if step >= 50:
+            break
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `download_tiny_shakespeare` and `TextDiffusionDataset` helpers
- export data utilities and add 10M tiny Shakespeare training demo
- cover dataset loader and diffusion dataset with unit tests

## Testing
- `black ironcortex/data.py ironcortex/__init__.py tests/test_data.py train_tiny_shakespeare.py`
- `ruff check ironcortex/data.py ironcortex/__init__.py tests/test_data.py train_tiny_shakespeare.py`
- ❌ `pytest` *(missing torch; attempted `pip install torch --index-url https://download.pytorch.org/whl/cpu` but install failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4d458ccc83258f3b5116d7051114