### PR TITLE
Fix missing Tuple import in PlannerHead

### DIFF
--- a/ironcortex/heads.py
+++ b/ironcortex/heads.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Tuple
 
 import torch
 import torch.nn as nn


### PR DESCRIPTION
## Summary
- import `Tuple` in `heads.py` to resolve NameError when running demo

## Testing
- `ruff check ironcortex/heads.py`
- `black --check ironcortex/heads.py` *(fails: would reformat)*
- `pytest` *(fails: No module named 'torch')*
- `pip install torch` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_68bb51aa62608325ba423ab360ce520b