### PR TITLE
Fix tiny shakespeare demo region count

### DIFF
--- a/train_tiny_shakespeare.py
+++ b/train_tiny_shakespeare.py
@@ -13,7 +13,11 @@ from ironcortex import (
 
 
 def build_model(device: torch.device) -> CortexReasoner:
-    cfg = CortexConfig(R=32, d=256, V=256, K_inner=8, B_br=2, k_active=8, max_T=512)
+    # The wiring helpers assume the region count forms a perfect square so that
+    # regions can be arranged on a 2D grid. Using a non-square value (e.g. 32)
+    # caused `hex_neighbors_grid` to raise an assertion error. Set ``R`` to a
+    # square number (36 = 6x6 grid) to make the demo run.
+    cfg = CortexConfig(R=36, d=256, V=256, K_inner=8, B_br=2, k_active=8, max_T=512)
     side = int(cfg.R**0.5)
     neighbors = hex_neighbors_grid(cfg.R, side)
     reg_coords = hex_axial_coords_from_grid(cfg.R, side)


### PR DESCRIPTION
## Summary
- set number of regions to 36 so grid wiring has a square layout and the demo runs

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch` *(fails: Could not find a version that satisfies the requirement torch: Tunnel connection failed 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bb55e985e08325977a55151dbcc442