### PR TITLE
Fix device mismatch in RWKVRegionCell rotation

### DIFF
--- a/ironcortex/region.py
+++ b/ironcortex/region.py
@@ -32,7 +32,9 @@ class RWKVRegionCell(nn.Module):
         # Iron time rotation pairs for v
         self.m_time = max(0, min(d // 8 // 2, m_time_pairs))
         if self.m_time > 0:
-            self.W_time = make_freq_bank(self.m_time, 1, kind="log", base=10000.0)
+            self.register_buffer(
+                "W_time", make_freq_bank(self.m_time, 1, kind="log", base=10000.0)
+            )
 
     def decay_vec(self) -> torch.Tensor:
         return torch.sigmoid(self.decay_param).pow(2.0)  # (0,1)


### PR DESCRIPTION
## Summary
- register `W_time` frequency bank as buffer so it moves with model across devices

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch -q` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_68bb59a2eda88325a79995b5add88383