### PR TITLE
Detach workspace each step and add CSV logging

### DIFF
--- a/train_tiny_shakespeare.py
+++ b/train_tiny_shakespeare.py
@@ -42,11 +42,19 @@ def main() -> None:
     optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
     lamb = LossWeights()
 
+    header = "step,ff,rtd,denoise,critic,verify,total,gain_mean,tau_mean"
+    print(header)
     for step, batch in enumerate(loader, 1):
         batch = batch.to(device)
         metrics = train_step(model, optimizer, batch, lamb, device)
-        if step % 10 == 0:
-            print(f"step {step}: loss={metrics['total']:.3f}")
+        gain_mean = float(model.gate.gain_ema.mean().item())
+        tau_mean = sum(r.tau for r in model.reg_ff) / model.R
+        line = (
+            f"{step},{metrics['ff']:.4f},{metrics['rtd']:.4f},{metrics['denoise']:.4f},"
+            f"{metrics['critic']:.4f},{metrics['verify']:.4f},{metrics['total']:.4f},"
+            f"{gain_mean:.4f},{tau_mean:.4f}"
+        )
+        print(line)
         if step >= 50:
             break
 


### PR DESCRIPTION
## Summary
- detach workspace scratchpad between reasoning runs to prevent autograd graph reuse
- log training progress in CSV format including loss breakdown and gate stats

## Testing
- `black ironcortex/training.py train_tiny_shakespeare.py`
- `ruff check ironcortex/training.py train_tiny_shakespeare.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68bb5d2fdee8832597626e8ea0f87ce3