### PR TITLE
Add dropout flag and improve forward-forward metrics

### DIFF
--- a/ironcortex/config.py
+++ b/ironcortex/config.py
@@ -1,11 +1,15 @@
 from dataclasses import dataclass
 
+
 @dataclass
 class CortexConfig:
     R: int = 32
     d: int = 128
-    V: int = 256           # vocab size (e.g., bytes)
+    V: int = 256  # vocab size (e.g., bytes)
     K_inner: int = 8
     B_br: int = 2
     k_active: int = 8
     max_T: int = 8192
+    use_dropout: bool = False
+    attn_pdrop: float = 0.0
+    resid_pdrop: float = 0.0

--- a/ironcortex/gate.py
+++ b/ironcortex/gate.py
@@ -84,6 +84,10 @@ class Gate(nn.Module):
     def update_gain(self, r: int, goodness_gain: float, beta: float = 0.9):
         self.gain_ema[r] = beta * self.gain_ema[r] + (1.0 - beta) * float(goodness_gain)
 
+    def update_gain_tensor(self, gains: torch.Tensor, beta: float = 0.9):
+        """Vectorized gain update: gains[R] tensor."""
+        self.gain_ema.mul_(beta).add_(gains * (1.0 - beta))
+
     def update_homeo(
         self, reg_mask: torch.Tensor, eta: float = 1e-3, target: float = 0.1
     ):

--- a/ironcortex/utils.py
+++ b/ironcortex/utils.py
@@ -1,5 +1,3 @@
-import math
-import random
 from typing import List, Tuple
 
 import torch
@@ -9,6 +7,7 @@ import torch.nn.functional as F
 
 # ==========================================================
 
+
 class RMSNorm(nn.Module):
     """Root-Mean-Square LayerNorm with learnable scale (weight).
 
@@ -16,6 +15,7 @@ class RMSNorm(nn.Module):
     Keeps magnitudes comparable, which is important because FF goodness
     is defined on post-norm activations (mean(x^2)).
     """
+
     def __init__(self, d: int, eps: float = 1e-5):
         super().__init__()
         self.eps = eps
@@ -39,7 +39,7 @@ def KWTA(x: torch.Tensor, k: int) -> torch.Tensor:
     absx = x.abs()
     # threshold at the kth largest absolute value (ties keep extra units)
     thresh = torch.topk(absx, k, dim=-1).values[..., -1:].expand_as(absx)
-    mask = (absx >= thresh)
+    mask = absx >= thresh
     return x * mask
 
 
@@ -127,7 +127,9 @@ def schedule_burst(u_mean: float, v_hat: float, R: int) -> int:
     return 0
 
 
-def should_halt(branch_scores: List[torch.Tensor], u_mean: float, k: int, K_inner: int) -> bool:
+def should_halt(
+    branch_scores: List[torch.Tensor], u_mean: float, k: int, K_inner: int
+) -> bool:
     """Early halting when confident and enough micro-steps done."""
     return (u_mean < 0.05) and (k >= max(1, K_inner // 2))
 
@@ -136,17 +138,22 @@ def should_halt(branch_scores: List[torch.Tensor], u_mean: float, k: int, K_inne
 # 3) Goodness & Region FF State
 # ==========================================================
 
+
 def goodness(h_stack: torch.Tensor) -> torch.Tensor:
-    """Scalar FF goodness on a stack of post-norm activations: mean of squared."""
-    return (h_stack.pow(2).mean(dim=-1)).mean()  # average across stack and channels
+    """Scalar FF goodness on a stack of post-norm activations.
+
+    The reduction is performed in float32 to keep thresholds stable under AMP.
+    """
+    h = h_stack.float()
+    return (h.pow(2).mean(dim=-1)).mean()
 
 
-class RegionFFState:
-    """Per-region FF threshold τ (EMA)."""
+class RegionFFState(nn.Module):
+    """Per-region FF threshold τ (EMA) stored as a buffer."""
+
     def __init__(self, init_tau: float = 0.0):
-        self.tau = float(init_tau)
+        super().__init__()
+        self.register_buffer("tau", torch.tensor(init_tau, dtype=torch.float32))
 
-    def update_tau(self, g_pos_mean: float, alpha: float = 0.01):
-        self.tau = (1.0 - alpha) * self.tau + alpha * float(g_pos_mean)
-
-
+    def update_tau(self, g_pos_mean: torch.Tensor, alpha: float = 0.01):
+        self.tau.lerp_(g_pos_mean, alpha)

--- a/train_tiny_shakespeare.py
+++ b/train_tiny_shakespeare.py
@@ -48,7 +48,7 @@ def main() -> None:
         batch = batch.to(device)
         metrics = train_step(model, optimizer, batch, lamb, device)
         gain_mean = float(model.gate.gain_ema.mean().item())
-        tau_mean = sum(r.tau for r in model.reg_ff) / model.R
+        tau_mean = float(torch.stack([r.tau for r in model.reg_ff]).mean().item())
         line = (
             f"{step},{metrics['ff']:.4f},{metrics['rtd']:.4f},{metrics['denoise']:.4f},"
             f"{metrics['critic']:.4f},{metrics['verify']:.4f},{metrics['ce']:.4f},"


### PR DESCRIPTION
## Summary
- add configuration flag to disable dropout and wire through Iron RoPE attention
- compute FF goodness in float32 with per-region τ buffers and vectorized gain updates
- generate negative samples with torch ops and expose average τ in tiny Shakespeare demo

## Testing
- `ruff check ironcortex/config.py ironcortex/corruptions.py ironcortex/gate.py ironcortex/iron_rope.py ironcortex/model.py ironcortex/training.py ironcortex/utils.py train_tiny_shakespeare.py`  
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68bb7f775e38832582f33e1eecdfc06c