### PR TITLE
Add diffusion generation and training hyperparameters

### DIFF
--- a/ironcortex/__init__.py
+++ b/ironcortex/__init__.py
@@ -2,6 +2,10 @@ from .config import CortexConfig as CortexConfig
 from .model import CortexReasoner as CortexReasoner
 from .training import LossWeights as LossWeights, train_step as train_step
 from .generation import generate as generate
+from .diffusion import (
+    DiffusionConfig as DiffusionConfig,
+    diffusion_generate as diffusion_generate,
+)
 from .wiring import (
     hex_neighbors_grid as hex_neighbors_grid,
     hex_axial_coords_from_grid as hex_axial_coords_from_grid,

--- a/ironcortex/diffusion.py
+++ b/ironcortex/diffusion.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Iterable, Optional
+
+import torch
+
+from .model import CortexReasoner
+
+
+@dataclass
+class DiffusionConfig:
+    """Hyperparameters for diffusion generation."""
+
+    steps: int = 4
+    noise_start: float = 1.0
+    noise_end: float = 0.0
+
+
+@torch.no_grad()
+def diffusion_generate(
+    model: CortexReasoner,
+    prompt_tokens: torch.Tensor,
+    T_total: int,
+    diff_cfg: Optional[DiffusionConfig] = None,
+    region_generators: Optional[
+        Iterable[Callable[[torch.Tensor], torch.Tensor]]
+    ] = None,
+) -> torch.Tensor:
+    """Generate tokens using a simple diffusion-style denoising loop.
+
+    Parameters
+    ----------
+    model:
+        The ``CortexReasoner`` used to denoise sequences.
+    prompt_tokens:
+        Conditioning prompt of shape ``[T0]`` (dtype ``torch.long``).
+    T_total:
+        Total length of sequence to generate.
+    diff_cfg:
+        Configuration controlling diffusion steps and noise schedule.
+    region_generators:
+        Optional hooks for region-specific generators. Each callable receives
+        the current token sequence and returns an updated version. These hooks
+        can later be implemented asynchronously on separate nodes.
+    """
+
+    if diff_cfg is None:
+        diff_cfg = DiffusionConfig()
+
+    device = next(model.parameters()).device
+    T0 = prompt_tokens.shape[0]
+    tokens = torch.randint(low=0, high=model.V - 1, size=(T_total,), device=device)
+    tokens[:T0] = prompt_tokens.to(device)
+    H_prev, reg_mask_prev = model.zeros_state(device)
+
+    for step in range(diff_cfg.steps, 0, -1):
+        noise_p = (
+            diff_cfg.noise_end
+            + (diff_cfg.noise_start - diff_cfg.noise_end) * step / diff_cfg.steps
+        )
+        mask = torch.rand(T_total, device=device) < noise_p
+        noisy = tokens.clone()
+        if mask.any():
+            noisy[mask] = torch.randint(
+                0, model.V - 1, size=(int(mask.sum()),), device=device
+            )
+        focus_map = torch.ones(T_total, dtype=torch.bool, device=device)
+        H_prev, reg_mask_prev, logits, traces = model.reasoning_loop(
+            noisy, model.cfg.K_inner, focus_map, reg_mask_prev, H_prev
+        )
+        tokens = logits.argmax(dim=-1)
+        if region_generators:
+            for fn in region_generators:
+                tokens = fn(tokens)
+
+    return tokens

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,15 +1,18 @@
 import random
+
 import torch
 import pytest
 
 from ironcortex import (
     CortexConfig,
     CortexReasoner,
+    DiffusionConfig,
     LossWeights,
-    train_step,
+    diffusion_generate,
     generate,
-    hex_neighbors_grid,
     hex_axial_coords_from_grid,
+    hex_neighbors_grid,
+    train_step,
 )
 
 
@@ -32,6 +35,10 @@ def test_smoke():
     prompt = torch.randint(low=0, high=cfg.V - 1, size=(4,), device=device)
     out = generate(model, prompt, T_total=8, max_outer_iters=2, conf_threshold=0.8)
     assert out.shape[0] == 8
+    diff_out = diffusion_generate(
+        model, prompt, T_total=8, diff_cfg=DiffusionConfig(steps=2)
+    )
+    assert diff_out.shape[0] == 8
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")

--- a/train_tiny_shakespeare.py
+++ b/train_tiny_shakespeare.py
@@ -1,15 +1,32 @@
 import random
+from dataclasses import dataclass
+
 import torch
 
 from ironcortex import (
     CortexConfig,
     CortexReasoner,
+    DiffusionConfig,
     LossWeights,
-    train_step,
-    load_tiny_shakespeare,
-    hex_neighbors_grid,
+    diffusion_generate,
     hex_axial_coords_from_grid,
+    hex_neighbors_grid,
+    load_tiny_shakespeare,
+    train_step,
 )
+
+
+@dataclass
+class TrainHyperParams:
+    """Knobs controlling the Tiny Shakespeare demo."""
+
+    epochs: int = 1
+    max_steps: int = 50
+    log_interval: int = 10
+    batch_size: int = 8
+    seq_len: int = 256
+    gen_tokens: int = 128
+    diffusion_steps: int = 4
 
 
 def build_model(device: torch.device) -> CortexReasoner:
@@ -26,37 +43,64 @@ def build_model(device: torch.device) -> CortexReasoner:
     return model
 
 
+def train(
+    model: CortexReasoner, loader, hparams: TrainHyperParams, device: torch.device
+) -> None:
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
+    lamb = LossWeights()
+    header = "step,ff,rtd,denoise,critic,verify,ce,total,gain_mean,tau_mean"
+    print(header)
+    step = 0
+    for epoch in range(1, hparams.epochs + 1):
+        for batch in loader:
+            step += 1
+            batch = batch.to(device)
+            metrics = train_step(model, optimizer, batch, lamb, device)
+            gain_mean = float(model.gate.gain_ema.mean().item())
+            tau_mean = sum(r.tau for r in model.reg_ff) / model.R
+            if step % hparams.log_interval == 0:
+                line = (
+                    f"{step},{metrics['ff']:.4f},{metrics['rtd']:.4f},{metrics['denoise']:.4f},"
+                    f"{metrics['critic']:.4f},{metrics['verify']:.4f},{metrics['ce']:.4f},"
+                    f"{metrics['total']:.4f},{gain_mean:.4f},{tau_mean:.4f}"
+                )
+                print(line)
+            if hparams.max_steps and step >= hparams.max_steps:
+                return
+
+
+def run_generation(
+    model: CortexReasoner, prompt_text: str, hparams: TrainHyperParams
+) -> None:
+    device = next(model.parameters()).device
+    prompt = torch.tensor(
+        list(prompt_text.encode("utf-8")), dtype=torch.long, device=device
+    )
+    diff_cfg = DiffusionConfig(steps=hparams.diffusion_steps)
+    out = diffusion_generate(
+        model, prompt, T_total=hparams.gen_tokens, diff_cfg=diff_cfg
+    )
+    text = bytes(out.tolist()).decode("utf-8", errors="ignore")
+    print(text)
+
+
 def main() -> None:
     torch.manual_seed(0)
     random.seed(0)
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    hparams = TrainHyperParams()
     tokens = load_tiny_shakespeare("data")
-    seq_len = 256
-    n_seq = len(tokens) // seq_len
-    tokens = tokens[: n_seq * seq_len].view(n_seq, seq_len)
-    loader = torch.utils.data.DataLoader(tokens, batch_size=8, shuffle=True)
+    n_seq = len(tokens) // hparams.seq_len
+    tokens = tokens[: n_seq * hparams.seq_len].view(n_seq, hparams.seq_len)
+    loader = torch.utils.data.DataLoader(
+        tokens, batch_size=hparams.batch_size, shuffle=True
+    )
 
     model = build_model(device)
     n_params = sum(p.numel() for p in model.parameters())
     print(f"model parameters: {n_params/1e6:.2f}M")
-    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
-    lamb = LossWeights()
-
-    header = "step,ff,rtd,denoise,critic,verify,ce,total,gain_mean,tau_mean"
-    print(header)
-    for step, batch in enumerate(loader, 1):
-        batch = batch.to(device)
-        metrics = train_step(model, optimizer, batch, lamb, device)
-        gain_mean = float(model.gate.gain_ema.mean().item())
-        tau_mean = sum(r.tau for r in model.reg_ff) / model.R
-        line = (
-            f"{step},{metrics['ff']:.4f},{metrics['rtd']:.4f},{metrics['denoise']:.4f},"
-            f"{metrics['critic']:.4f},{metrics['verify']:.4f},{metrics['ce']:.4f},"
-            f"{metrics['total']:.4f},{gain_mean:.4f},{tau_mean:.4f}"
-        )
-        print(line)
-        if step >= 50:
-            break
+    train(model, loader, hparams, device)
+    run_generation(model, "ROMEO:", hparams)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `DiffusionConfig` and `diffusion_generate` for simple diffusion-style token generation
- expose diffusion helpers in `ironcortex.__init__`
- refactor Tiny Shakespeare demo with training hyperparameters and diffusion generation step
- extend smoke test to cover diffusion generation

## Testing
- `black ironcortex/diffusion.py ironcortex/__init__.py train_tiny_shakespeare.py tests/test_smoke.py`
- `ruff check ironcortex/diffusion.py ironcortex/__init__.py train_tiny_shakespeare.py tests/test_smoke.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68bb864015008325ba544140eff18681