### PR TITLE
Optimize FF training and add dropout flag

### DIFF
--- a/ironcortex/config.py
+++ b/ironcortex/config.py
@@ -1,11 +1,14 @@
 from dataclasses import dataclass
 
+
 @dataclass
 class CortexConfig:
     R: int = 32
     d: int = 128
-    V: int = 256           # vocab size (e.g., bytes)
+    V: int = 256  # vocab size (e.g., bytes)
     K_inner: int = 8
     B_br: int = 2
     k_active: int = 8
     max_T: int = 8192
+    # Optional dropout in goodness path (disabled by default)
+    ff_dropout: bool = False

--- a/train_tiny_shakespeare.py
+++ b/train_tiny_shakespeare.py
@@ -57,7 +57,7 @@ def train(
             batch = batch.to(device)
             metrics = train_step(model, optimizer, batch, lamb, device)
             gain_mean = float(model.gate.gain_ema.mean().item())
-            tau_mean = sum(r.tau for r in model.reg_ff) / model.R
+            tau_mean = float(torch.stack([r.tau for r in model.reg_ff]).mean().item())
             if step % hparams.log_interval == 0:
                 line = (
                     f"{step},{metrics['ff']:.4f},{metrics['rtd']:.4f},{metrics['denoise']:.4f},"


### PR DESCRIPTION
## Summary
- add `ff_dropout` config flag and wire optional dropout through Iron RoPE modules
- batch positive and negative streams in one forward and update `tau` buffers on-device
- rewrite corruption ops and goodness calculations for GPU and FP32 stability

## Testing
- `black ironcortex/config.py ironcortex/corruptions.py ironcortex/iron_rope.py ironcortex/model.py ironcortex/training.py ironcortex/utils.py train_tiny_shakespeare.py`
- `ruff check .`
- `pytest` *(fails: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68bb89dbd2808325b1716195b50e05de