### PR TITLE
Add seed flag with random default to Tiny Shakespeare demo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,10 @@ train_tiny_shakespeare.py  # Example training script
 2. Train on Tiny Shakespeare:
 
    ```bash
-   python train_tiny_shakespeare.py
+   python train_tiny_shakespeare.py --seed 1234  # optional
    ```
+
+   The `--seed` flag controls reproducibility. If omitted, a random seed is
+   chosen each run.
 
 The repository is under active development. Replace the grid wiring with true hex axial layouts, swap in alternative token heads, and strengthen verifier targets to explore new reasoning behaviors.


### PR DESCRIPTION
## Summary
- allow passing `--seed` to training demo and pick a new random seed when omitted
- document `--seed` flag in the README

## Testing
- `black train_tiny_shakespeare.py`
- `ruff check .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch', torch install blocked: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bee76fb8e883259042577a39bd4239