### PR TITLE
Implement hex axial wiring layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,7 +264,7 @@ If such components are added, document their usage and locations here.
 - Modify `generation.py` to experiment with new confidence strategies or routing heuristics.
 
 #### Wiring and Geometry
-- Use `hex_neighbors_grid()` and `hex_axial_coords_from_grid()` from `wiring.py` to build region graphs.
+- Use `hex_neighbors()` and `hex_axial_coords()` from `wiring.py` to build region graphs.
 - For true hex axial layouts or alternative topologies, add new helpers here.
 
 #### Adding New Modules

--- a/ironcortex/__init__.py
+++ b/ironcortex/__init__.py
@@ -13,8 +13,8 @@ from .diffusion import (
     diffusion_generate as diffusion_generate,
 )
 from .wiring import (
-    hex_neighbors_grid as hex_neighbors_grid,
-    hex_axial_coords_from_grid as hex_axial_coords_from_grid,
+    hex_neighbors as hex_neighbors,
+    hex_axial_coords as hex_axial_coords,
 )
 from .data import (
     download_tiny_shakespeare as download_tiny_shakespeare,

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -10,8 +10,8 @@ from ironcortex import (
     LossWeights,
     diffusion_generate,
     generate,
-    hex_axial_coords_from_grid,
-    hex_neighbors_grid,
+    hex_axial_coords,
+    hex_neighbors,
     train_step,
 )
 
@@ -20,9 +20,8 @@ def test_smoke():
     torch.manual_seed(0)
     random.seed(0)
     cfg = CortexConfig(R=4, d=32, V=20, K_inner=2, B_br=1, k_active=2, max_T=64)
-    side = int(cfg.R**0.5)
-    neighbors = hex_neighbors_grid(cfg.R, side)
-    reg_coords = hex_axial_coords_from_grid(cfg.R, side)
+    neighbors = hex_neighbors(cfg.R)
+    reg_coords = hex_axial_coords(cfg.R)
     io_idxs = {"sensor": 0, "motor": cfg.R - 1}
     device = torch.device("cpu")
     model = CortexReasoner(neighbors, reg_coords, io_idxs, cfg).to(device)
@@ -47,9 +46,8 @@ def test_router_fourier_bias_device():
     torch.manual_seed(0)
     random.seed(0)
     cfg = CortexConfig(R=4, d=32, V=20, K_inner=2, B_br=1, k_active=2, max_T=64)
-    side = int(cfg.R**0.5)
-    neighbors = hex_neighbors_grid(cfg.R, side)
-    reg_coords = hex_axial_coords_from_grid(cfg.R, side)
+    neighbors = hex_neighbors(cfg.R)
+    reg_coords = hex_axial_coords(cfg.R)
     io_idxs = {"sensor": 0, "motor": cfg.R - 1}
     device = torch.device("cuda")
     model = CortexReasoner(neighbors, reg_coords, io_idxs, cfg).to(device)

--- a/tests/test_wiring.py
+++ b/tests/test_wiring.py
@@ -1,0 +1,20 @@
+import torch
+
+from ironcortex.wiring import hex_axial_coords, hex_neighbors
+
+
+def test_hex_axial_coords_clockwise_spiral():
+    coords = hex_axial_coords(7)
+    expected = torch.tensor(
+        [[0, 0], [1, 0], [1, -1], [0, -1], [-1, 0], [-1, 1], [0, 1]],
+        dtype=torch.float32,
+    )
+    assert torch.equal(coords, expected)
+
+
+def test_hex_neighbors_basic():
+    neighbors = hex_neighbors(7)
+    # center connects to all six surrounding regions
+    assert set(neighbors[0]) == set(range(1, 7))
+    # first region on outer ring connects to center and its two adjacent cells
+    assert set(neighbors[1]) == {0, 2, 6}

--- a/train_tiny_shakespeare.py
+++ b/train_tiny_shakespeare.py
@@ -11,8 +11,8 @@ from ironcortex import (
     LossWeights,
     generate,
     diffusion_generate,
-    hex_axial_coords_from_grid,
-    hex_neighbors_grid,
+    hex_axial_coords,
+    hex_neighbors,
     load_tiny_shakespeare,
     train_step,
 )
@@ -33,14 +33,9 @@ class TrainHyperParams:
 
 
 def build_model(device: torch.device) -> CortexReasoner:
-    # The wiring helpers assume the region count forms a perfect square so that
-    # regions can be arranged on a 2D grid. Using a non-square value (e.g. 32)
-    # caused `hex_neighbors_grid` to raise an assertion error. Set ``R`` to a
-    # square number (36 = 6x6 grid) to make the demo run.
     cfg = CortexConfig(R=36, d=256, V=256, K_inner=8, B_br=2, k_active=8, max_T=512)
-    side = int(cfg.R**0.5)
-    neighbors = hex_neighbors_grid(cfg.R, side)
-    reg_coords = hex_axial_coords_from_grid(cfg.R, side)
+    neighbors = hex_neighbors(cfg.R)
+    reg_coords = hex_axial_coords(cfg.R)
     io_idxs = {"sensor": 0, "motor": cfg.R - 1}
     model = CortexReasoner(neighbors, reg_coords, io_idxs, cfg).to(device)
     return model


### PR DESCRIPTION
## Summary
- replace square grid proxy with true hex axial layout
- expose `hex_neighbors` and `hex_axial_coords` wiring helpers
- add dedicated wiring tests and update imports

## Testing
- `ruff check ironcortex/__init__.py ironcortex/wiring.py tests/test_smoke.py tests/test_wiring.py train_tiny_shakespeare.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68beea82008c83258c8152f653be05a5