### PR TITLE
Fix generation sampling to avoid blank outputs

### DIFF
--- a/ironcortex/diffusion.py
+++ b/ironcortex/diffusion.py
@@ -66,7 +66,9 @@ def diffusion_generate(
         H_prev, reg_mask_prev, logits, traces = model.reasoning_loop(
             noisy, model.cfg.K_inner, focus_map, reg_mask_prev, H_prev
         )
-        tokens = logits.argmax(dim=-1)
+        logits[:, -1] = float("-inf")
+        probs = logits.softmax(dim=-1)
+        tokens = torch.multinomial(probs, num_samples=1).squeeze(-1)
         if region_generators:
             for fn in region_generators:
                 tokens = fn(tokens)

--- a/ironcortex/generation.py
+++ b/ironcortex/generation.py
@@ -50,7 +50,10 @@ def generate(
             with torch.enable_grad():
                 _, refined, _ = thinker.optimize(motor_state, probs)
             probs = refined.softmax(dim=-1)
-            pred = probs.argmax(dim=-1)
+            # avoid predicting the padding token (V-1)
+            probs[:, -1] = 0
+            probs = probs / probs.sum(dim=-1, keepdim=True)
+            pred = torch.multinomial(probs, num_samples=1).squeeze(-1)
             maxp = probs.max(dim=-1).values
             conf[:] = maxp
             tokens = torch.where(focus_map, pred, tokens)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -34,10 +34,14 @@ def test_smoke():
     prompt = torch.randint(low=0, high=cfg.V - 1, size=(4,), device=device)
     out = generate(model, prompt, T_total=8, max_outer_iters=2, conf_threshold=0.8)
     assert out.shape[0] == 8
+    assert (out != 0).any()
+    assert (out < cfg.V - 1).all()
     diff_out = diffusion_generate(
         model, prompt, T_total=8, diff_cfg=DiffusionConfig(steps=2)
     )
     assert diff_out.shape[0] == 8
+    assert (diff_out != 0).any()
+    assert (diff_out < cfg.V - 1).all()
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")


### PR DESCRIPTION
## Summary
- Sample tokens during generation and diffusion instead of argmax to avoid degenerate all-zero outputs
- Mask out the padding token during generation
- Add tests ensuring generated sequences contain non-zero tokens

## Testing
- `pytest -q` *(fails: No module named 'torch')*
- `black ironcortex/generation.py ironcortex/diffusion.py tests/test_smoke.py`
- `ruff check ironcortex/generation.py ironcortex/diffusion.py tests/test_smoke.py`

------
https://chatgpt.com/codex/tasks/task_e_68bef201b934832598a02840a16f0167