### PR TITLE
Fix IndexError in diffusion generation sampling

### DIFF
--- a/ironcortex/diffusion.py
+++ b/ironcortex/diffusion.py
@@ -66,9 +66,10 @@ def diffusion_generate(
         H_prev, reg_mask_prev, logits, traces = model.reasoning_loop(
             noisy, model.cfg.K_inner, focus_map, reg_mask_prev, H_prev
         )
-        logits[:, -1] = float("-inf")
+        logits[-1] = float("-inf")
         probs = logits.softmax(dim=-1)
-        tokens = torch.multinomial(probs, num_samples=1).squeeze(-1)
+        tokens = torch.multinomial(probs, num_samples=T_total, replacement=True)
+        tokens[:T0] = prompt_tokens.to(device)
         if region_generators:
             for fn in region_generators:
                 tokens = fn(tokens)

--- a/ironcortex/generation.py
+++ b/ironcortex/generation.py
@@ -51,7 +51,7 @@ def generate(
                 _, refined, _ = thinker.optimize(motor_state, probs)
             probs = refined.softmax(dim=-1)
             # avoid predicting the padding token (V-1)
-            probs[:, -1] = 0
+            probs[-1] = 0
             probs = probs / probs.sum(dim=-1, keepdim=True)
             pred = torch.multinomial(probs, num_samples=1).squeeze(-1)
             maxp = probs.max(dim=-1).values


### PR DESCRIPTION
## Summary
- avoid 2D indexing on 1D logits in diffusion generation
- sample full sequences and preserve prompts during diffusion
- guard against padding token in generation module without 2D index

## Testing
- `pytest` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68bef638ca5083259000a290cf671bb9