### PR TITLE
Improve cross-entropy and perplexity evaluation

### DIFF
--- a/ironcortex/__init__.py
+++ b/ironcortex/__init__.py
@@ -7,6 +7,7 @@ from .energy import (
     energy_descent_step as energy_descent_step,
 )
 from .ff_energy import ff_energy_loss as ff_energy_loss, ff_step as ff_step
+from .evaluation import evaluate_perplexity as evaluate_perplexity
 from .thinking import Thinker as Thinker
 from .diffusion import (
     DiffusionConfig as DiffusionConfig,

--- a/ironcortex/evaluation.py
+++ b/ironcortex/evaluation.py
@@ -1,0 +1,45 @@
+"""Evaluation utilities for cross entropy and perplexity."""
+
+import math
+from typing import Dict
+
+import torch
+import torch.nn.functional as F
+
+from .model import CortexReasoner
+
+
+@torch.no_grad()
+def evaluate_perplexity(
+    model: CortexReasoner, tokens: torch.Tensor, device: torch.device
+) -> Dict[str, float]:
+    """Compute cross entropy and perplexity for sequences with teacher forcing.
+
+    Args:
+        model: The ``CortexReasoner`` to evaluate.
+        tokens: Tensor of shape ``[B, T]`` containing token ids.
+        device: Device on which to run the computation.
+
+    Returns:
+        Dictionary with ``cross_entropy`` and ``perplexity``.
+    """
+    model.eval()
+    tokens = tokens.to(device)
+    B, T = tokens.shape
+    focus = torch.zeros(B, T, dtype=torch.bool, device=device)
+    total_nll = 0.0
+    total_tokens = 0
+
+    for t in range(T - 1):
+        ctx = tokens[:, : t + 1]
+        targets = tokens[:, t + 1]
+        _, _, logits, _ = model.reasoning_loop_batch(
+            ctx, model.cfg.K_inner, focus[:, : t + 1]
+        )
+        log_probs = F.log_softmax(logits, dim=-1)
+        total_nll += F.nll_loss(log_probs, targets, reduction="sum").item()
+        total_tokens += targets.numel()
+
+    cross_entropy = total_nll / max(1, total_tokens)
+    perplexity = float(math.exp(cross_entropy))
+    return {"cross_entropy": cross_entropy, "perplexity": perplexity}

--- a/ironcortex/training.py
+++ b/ironcortex/training.py
@@ -53,7 +53,7 @@ def train_step(
     total_denoise = 0.0
     total_critic = 0.0
     total_verify = 0.0
-    total_ce = 0.0
+    total_ce_last = 0.0
     total_E_pos = 0.0
     total_E_neg = 0.0
 
@@ -81,6 +81,7 @@ def train_step(
         logits_pos, logits_neg = logits_all
         traces_pos, traces_neg = traces_all
 
+        # Cross-entropy of the final token for quick monitoring
         ce_loss = F.cross_entropy(logits_pos.unsqueeze(0), tokens[-1].unsqueeze(0))
 
         # -------- FF per-region losses --------
@@ -181,7 +182,7 @@ def train_step(
         total_denoise += float(denoise_loss.detach().item())
         total_critic += float(critic_loss.detach().item())
         total_verify += float(verifier_loss.detach().item())
-        total_ce += float(ce_loss.detach().item())
+        total_ce_last += float(ce_loss.detach().item())
 
         model.gate.update_homeo(reg_mask_n)
 
@@ -195,6 +196,6 @@ def train_step(
         "verify": total_verify / B,
         "E_pos": total_E_pos / B,
         "E_neg": total_E_neg / B,
-        "ce": total_ce / B,
+        "ce_last": total_ce_last / B,
         "total": total_loss_val / B,
     }

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,0 +1,21 @@
+import torch
+
+from ironcortex import (
+    CortexConfig,
+    CortexReasoner,
+    evaluate_perplexity,
+    hex_axial_coords,
+    hex_neighbors,
+)
+
+
+def test_evaluate_perplexity_runs():
+    cfg = CortexConfig(R=2, d=8, V=16, K_inner=2, B_br=1, k_active=1, max_T=8)
+    neighbors = hex_neighbors(cfg.R)
+    coords = hex_axial_coords(cfg.R)
+    io = {"sensor": 0, "motor": cfg.R - 1}
+    model = CortexReasoner(neighbors, coords, io, cfg)
+    tokens = torch.randint(0, cfg.V, (1, 4), dtype=torch.long)
+    metrics = evaluate_perplexity(model, tokens, device=torch.device("cpu"))
+    assert metrics["cross_entropy"] > 0
+    assert metrics["perplexity"] > 0


### PR DESCRIPTION
## Summary
- add `evaluate_perplexity` helper to compute cross-entropy/perplexity via teacher forcing
- clarify training step metric as `ce_last`
- report full-sequence cross-entropy and perplexity in the Tiny Shakespeare demo

## Testing
- `ruff check .`
- `black ironcortex/evaluation.py ironcortex/__init__.py ironcortex/training.py train_tiny_shakespeare.py tests/test_eval.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68bf0f4b631c832588c70140c3d1f38d