### PR TITLE
Add training visualizer and periodic generation

### DIFF
--- a/ironcortex/__init__.py
+++ b/ironcortex/__init__.py
@@ -23,3 +23,4 @@ from .data import (
     TextDiffusionDataset as TextDiffusionDataset,
     TextDiffusionSample as TextDiffusionSample,
 )
+from .visualization import TrainVisualizer as TrainVisualizer

--- a/ironcortex/visualization.py
+++ b/ironcortex/visualization.py
@@ -1,0 +1,76 @@
+"""Realtime training visualization utilities.
+
+TODO: read AGENTS.md completely
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Dict, Iterable, Mapping
+
+import matplotlib.pyplot as plt
+
+
+@dataclass
+class TrainVisualizer:
+    """Plot training metrics with a dark themed realtime chart.
+
+    Parameters
+    ----------
+    axes_map:
+        Mapping of axis name to iterable of metric keys to plot on that axis. This
+        allows grouping metrics with similar scales on separate subplots.
+    """
+
+    axes_map: Mapping[str, Iterable[str]] | None = None
+
+    def __post_init__(self) -> None:
+        plt.style.use("dark_background")
+        if self.axes_map is None:
+            self.axes_map = {
+                "loss": ["ff", "rtd", "denoise", "critic", "verify", "total"],
+                "energy": ["E_pos", "E_neg"],
+                "eval": [
+                    "cross_entropy",
+                    "perplexity",
+                    "gain_mean",
+                    "tau_mean",
+                ],
+            }
+        n_axes = len(self.axes_map)
+        self.fig, axes = plt.subplots(n_axes, 1, figsize=(8, 2.5 * n_axes))
+        if not isinstance(axes, Iterable):  # pragma: no cover
+            axes = [axes]
+        self.axes: Dict[str, plt.Axes] = {}
+        self.lines: Dict[str, plt.Line2D] = {}
+        self.data: Dict[str, list[tuple[int, float]]] = defaultdict(list)
+        for ax, (axis_name, metrics) in zip(axes, self.axes_map.items()):
+            ax.set_title(axis_name)
+            for m in metrics:
+                (line,) = ax.plot([], [], label=m)
+                self.lines[m] = line
+            ax.legend(loc="upper right")
+            self.axes[axis_name] = ax
+        plt.tight_layout()
+        plt.ion()
+        plt.show(block=False)
+
+    def update(
+        self, step: int, metrics: Mapping[str, float], eval_metrics: Mapping[str, float]
+    ) -> None:
+        """Append new metrics and refresh the chart."""
+
+        combined: Dict[str, float] = {**metrics, **eval_metrics}
+        for key, val in combined.items():
+            if key in self.lines:
+                self.data[key].append((step, float(val)))
+                xs, ys = zip(*self.data[key])
+                line = self.lines[key]
+                line.set_data(xs, ys)
+                ax = line.axes
+                ax.relim()
+                ax.autoscale_view()
+        self.fig.canvas.draw()
+        self.fig.canvas.flush_events()
+        plt.pause(0.001)

--- a/tests/test_generation_interval.py
+++ b/tests/test_generation_interval.py
@@ -1,0 +1,41 @@
+import random
+
+import torch
+
+import train_tiny_shakespeare as tts
+from ironcortex import CortexConfig, CortexReasoner, hex_axial_coords, hex_neighbors
+
+
+def test_generation_interval(monkeypatch):
+    torch.manual_seed(0)
+    random.seed(0)
+    cfg = CortexConfig(R=4, d=32, V=20, K_inner=2, B_br=1, k_active=2, max_T=64)
+    neighbors = hex_neighbors(cfg.R)
+    reg_coords = hex_axial_coords(cfg.R)
+    io_idxs = {"sensor": 0, "motor": cfg.R - 1}
+    device = torch.device("cpu")
+    model = CortexReasoner(neighbors, reg_coords, io_idxs, cfg).to(device)
+    data = torch.randint(0, cfg.V - 1, size=(20, 8))
+    loader = torch.utils.data.DataLoader(data, batch_size=1)
+
+    calls = []
+
+    def fake_generate(
+        model, prompt, T_total, max_outer_iters=None, conf_threshold=None
+    ):
+        calls.append(T_total)
+        return torch.zeros(T_total, dtype=torch.long)
+
+    monkeypatch.setattr(tts, "generate", fake_generate)
+    hparams = tts.TrainHyperParams(
+        epochs=1,
+        max_steps=10,
+        log_interval=2,
+        gen_interval=5,
+        gen_tokens=8,
+        batch_size=1,
+        seq_len=8,
+        visualize=False,
+    )
+    tts.train(model, loader, hparams, device)
+    assert len(calls) == 2

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,0 +1,22 @@
+from ironcortex.visualization import TrainVisualizer
+
+
+def test_visualizer_update():
+    viz = TrainVisualizer()
+    metrics = {
+        "ff": 0.1,
+        "rtd": 0.2,
+        "denoise": 0.3,
+        "critic": 0.4,
+        "verify": 0.5,
+        "E_pos": 0.6,
+        "E_neg": 0.7,
+        "total": 2.8,
+    }
+    eval_metrics = {
+        "cross_entropy": 0.2,
+        "perplexity": 1.5,
+        "gain_mean": 0.1,
+        "tau_mean": 0.2,
+    }
+    viz.update(1, metrics, eval_metrics)


### PR DESCRIPTION
## Summary
- add reusable TrainVisualizer for dark-mode, real-time metric plots
- stream sample generations during training via configurable interval and prompt
- expose visualizer in package and cover with unit tests

## Testing
- `black ironcortex/visualization.py tests/test_visualization.py tests/test_generation_interval.py train_tiny_shakespeare.py ironcortex/__init__.py`
- `ruff check .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch --quiet --index-url https://download.pytorch.org/whl/cpu` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_68bf14258ed8832592df37c8fe9eb2b0