### PR TITLE
Handle Tiny Shakespeare download failures

### DIFF
--- a/ironcortex/data.py
+++ b/ironcortex/data.py
@@ -34,7 +34,13 @@ def download_tiny_shakespeare(root: str) -> str:
     os.makedirs(root, exist_ok=True)
     out_path = os.path.join(root, "tiny_shakespeare.txt")
     if not os.path.exists(out_path):
-        urllib.request.urlretrieve(TINY_SHAKESPEARE_URL, out_path)
+        try:
+            with urllib.request.urlopen(TINY_SHAKESPEARE_URL, timeout=30) as resp:
+                data = resp.read()
+            with open(out_path, "wb") as f:
+                f.write(data)
+        except Exception as e:  # pragma: no cover - network failures
+            raise RuntimeError("failed to download Tiny Shakespeare dataset") from e
     return out_path
 
 


### PR DESCRIPTION
## Summary
- avoid hanging when fetching Tiny Shakespeare by downloading with a 30s timeout

## Testing
- `black ironcortex/data.py`
- `ruff check .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68bf165651548325a17c68649308dff9