### PR TITLE
Handle visualization in headless training

### DIFF
--- a/ironcortex/visualization.py
+++ b/ironcortex/visualization.py
@@ -9,6 +9,9 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Dict, Iterable, Mapping
 
+import matplotlib
+
+matplotlib.use("Agg", force=True)
 import matplotlib.pyplot as plt
 
 
@@ -54,7 +57,10 @@ class TrainVisualizer:
             self.axes[axis_name] = ax
         plt.tight_layout()
         plt.ion()
-        plt.show(block=False)
+        try:  # pragma: no cover - headless environments
+            plt.show(block=False)
+        except Exception:
+            pass
 
     def update(
         self, step: int, metrics: Mapping[str, float], eval_metrics: Mapping[str, float]
@@ -72,5 +78,6 @@ class TrainVisualizer:
                 ax.relim()
                 ax.autoscale_view()
         self.fig.canvas.draw()
-        self.fig.canvas.flush_events()
+        if hasattr(self.fig.canvas, "flush_events"):
+            self.fig.canvas.flush_events()
         plt.pause(0.001)

--- a/train_tiny_shakespeare.py
+++ b/train_tiny_shakespeare.py
@@ -34,7 +34,7 @@ class TrainHyperParams:
     seed: int | None = None
     gen_interval: int = 20
     gen_prompt: str = "ROMEO:"
-    visualize: bool = True
+    visualize: bool = False
 
 
 def build_model(device: torch.device) -> CortexReasoner:
@@ -54,7 +54,12 @@ def train(
     header = "step,ff,rtd,denoise,critic,verify,E_pos,E_neg,xent,ppl,total,gain_mean,tau_mean"
     print(header)
     step = 0
-    vis = TrainVisualizer() if hparams.visualize else None
+    vis = None
+    if hparams.visualize:
+        try:
+            vis = TrainVisualizer()
+        except Exception as e:  # pragma: no cover - visualization optional
+            print(f"visualization disabled: {e}")
     prompt_ids = torch.tensor(
         list(hparams.gen_prompt.encode("utf-8")), dtype=torch.long, device=device
     )


### PR DESCRIPTION
## Summary
- avoid freezes by setting Tiny Shakespeare demo visualization off by default
- make `TrainVisualizer` fall back to a non-interactive backend and ignore display errors

## Testing
- `black train_tiny_shakespeare.py ironcortex/visualization.py`
- `ruff check ironcortex/visualization.py train_tiny_shakespeare.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1a970e9c8325b705828bd45f100f