### PR TITLE
Fix energy-based generation sampling

### DIFF
--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -34,7 +34,7 @@ def test_smoke():
     prompt = torch.randint(low=0, high=cfg.V - 1, size=(4,), device=device)
     out = generate(model, prompt, T_total=8, max_outer_iters=2, conf_threshold=0.8)
     assert out.shape[0] == 8
-    assert (out != 0).any()
+    assert (out != 0).all()
     assert (out < cfg.V - 1).all()
     diff_out = diffusion_generate(
         model, prompt, T_total=8, diff_cfg=DiffusionConfig(steps=2)


### PR DESCRIPTION
## Summary
- ensure energy-based generator samples per-token instead of repeating one token
- mask out NUL and padding tokens during sampling
- tighten smoke test to catch NUL outputs

## Testing
- `pytest tests/test_smoke.py::test_smoke -q` *(fails: ModuleNotFoundError: No module named 'torch')*
- `python -m black ironcortex/generation.py`
- `python -m black tests/test_smoke.py`
- `python -m ruff check ironcortex/generation.py`
- `python -m ruff check tests/test_smoke.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf22c01c848325a93424a3a612d05e