### PR TITLE
Separate perplexity axis in training visualizer

### DIFF
--- a/ironcortex/visualization.py
+++ b/ironcortex/visualization.py
@@ -40,12 +40,8 @@ class TrainVisualizer:
             self.axes_map = {
                 "loss": ["ff", "rtd", "denoise", "critic", "verify", "total"],
                 "energy": ["E_pos", "E_neg"],
-                "eval": [
-                    "cross_entropy",
-                    "perplexity",
-                    "gain_mean",
-                    "tau_mean",
-                ],
+                "eval": ["cross_entropy", "gain_mean", "tau_mean"],
+                "perplexity": ["perplexity"],
             }
         n_axes = len(self.axes_map)
         self.fig, axes = plt.subplots(n_axes, 1, figsize=(8, 2.5 * n_axes))

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -3,6 +3,8 @@ from ironcortex.visualization import TrainVisualizer
 
 def test_visualizer_update():
     viz = TrainVisualizer()
+    assert "perplexity" not in viz.axes_map["eval"]
+    assert viz.axes_map["perplexity"] == ["perplexity"]
     metrics = {
         "ff": 0.1,
         "rtd": 0.2,


### PR DESCRIPTION
## Summary
- Keep perplexity off the eval axis and render it on its own subplot
- Cover the new default axes layout in the visualization test

## Testing
- `ruff check .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_68bf24abed0083259d9db4ad62fa2743