### PR TITLE
feat: add sparse token encoder

### DIFF
--- a/docs/numenta_htm_integration.md
+++ b/docs/numenta_htm_integration.md
@@ -6,8 +6,8 @@ Iron Cortex already employs several biologically inspired components. This docum
 bringing ideas from Numenta's Thousand Brains Theory and Hierarchical Temporal Memory (HTM) into the codebase.
 
 ## 1. Strengthen Sparse Representations
-- **Spatial pooler style token encodings** – Replace the dense token embedding with a sparse distributed representation to
-  mirror HTM encoders. The current model uses a standard embedding layer[model-embed].
+- **Spatial pooler style token encodings** – Implemented via a fixed sparse distributed representation (`SparseTokenEncoder`)
+  replacing the dense embedding layer[model-embed].
 - **Diverse region receptive fields** – Introduce sparsity masks on router edge weights so regions specialize to different
   feature subsets. At present every neighbor connection owns a full linear transform[router-edges].
 - **Tune KWTA and homeostasis** – Experiment with smaller `k` in KWTA and lower `k_active` for the gate. The region cell
@@ -40,7 +40,7 @@ These steps aim to make Iron Cortex sparser, more predictive, and more adaptive 
 learning framework.
 
 <!-- References -->
-[model-embed]: ../ironcortex/model.py#L48-L49
+[model-embed]: ../ironcortex/model.py#L49-L51
 [router-edges]: ../ironcortex/gate.py#L110-L114
 [region-kwta]: ../ironcortex/region.py#L84-L85
 [gate-homeo]: ../ironcortex/gate.py#L89-L93

--- a/ironcortex/__init__.py
+++ b/ironcortex/__init__.py
@@ -24,3 +24,4 @@ from .data import (
     TextDiffusionSample as TextDiffusionSample,
 )
 from .visualization import TrainVisualizer as TrainVisualizer
+from .sdr import SparseTokenEncoder as SparseTokenEncoder

--- a/ironcortex/config.py
+++ b/ironcortex/config.py
@@ -6,6 +6,7 @@ class CortexConfig:
     R: int = 32
     d: int = 128
     V: int = 256  # vocab size (e.g., bytes)
+    sdr_k: int = 16  # active bits in sparse token encoding
     K_inner: int = 8
     B_br: int = 2
     k_active: int = 8

--- a/ironcortex/model.py
+++ b/ironcortex/model.py
@@ -4,6 +4,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from .config import CortexConfig
+from .sdr import SparseTokenEncoder
 from .utils import (
     uncertainty_from_logits,
     should_halt,
@@ -46,7 +47,7 @@ class CortexReasoner(nn.Module):
         self.register_buffer("reg_coords", reg_coords.to(torch.float32))
 
         # Tokens
-        self.embed = nn.Embedding(self.V, self.d)
+        self.embed = SparseTokenEncoder(self.V, self.d, cfg.sdr_k)
 
         # Regions
         self.regions = nn.ModuleList([RWKVRegionCell(self.d) for _ in range(self.R)])

--- a/ironcortex/sdr.py
+++ b/ironcortex/sdr.py
@@ -1,0 +1,28 @@
+import torch
+import torch.nn as nn
+
+
+class SparseTokenEncoder(nn.Module):
+    """Fixed sparse distributed token encodings.
+
+    Each vocabulary item is assigned a random binary vector with ``k`` active
+    bits out of ``d`` dimensions. The codes are non-trainable and stored as a
+    buffer to mirror HTM-style spatial pooler encoders.
+    """
+
+    def __init__(self, V: int, d: int, k: int) -> None:
+        super().__init__()
+        if k > d:
+            raise ValueError("k must be <= d")
+        self.V = V
+        self.d = d
+        self.k = k
+        # Pre-generate random sparse binary codes
+        codes = torch.zeros(V, d)
+        for i in range(V):
+            idx = torch.randperm(d)[:k]
+            codes[i, idx] = 1.0
+        self.register_buffer("codes", codes)
+
+    def forward(self, tokens: torch.Tensor) -> torch.Tensor:
+        return self.codes[tokens]

--- a/tests/test_sparse_encoder.py
+++ b/tests/test_sparse_encoder.py
@@ -1,0 +1,15 @@
+import torch
+
+from ironcortex import CortexConfig, CortexReasoner, hex_axial_coords, hex_neighbors
+
+
+def test_sparse_token_encoder_k_active():
+    cfg = CortexConfig(R=2, d=16, V=10, K_inner=1, B_br=1, k_active=1, max_T=8, sdr_k=4)
+    neighbors = hex_neighbors(cfg.R)
+    reg_coords = hex_axial_coords(cfg.R)
+    io_idxs = {"sensor": 0, "motor": cfg.R - 1}
+    model = CortexReasoner(neighbors, reg_coords, io_idxs, cfg)
+    tokens = torch.randint(0, cfg.V, (5,))
+    emb = model.embed(tokens)
+    assert (emb.sum(-1) == cfg.sdr_k).all()
+    assert ((emb == 0) | (emb == 1)).all()


### PR DESCRIPTION
## Summary
- add `SparseTokenEncoder` for fixed sparse token embeddings
- configure and integrate sparse embeddings in `CortexReasoner`
- document HTM spatial pooler integration and add unit test

## Testing
- `black .`
- `ruff check .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3e6a5e008325bfb76223e0c60a78