### PR TITLE
Implement predictive activation for temporal memory

### DIFF
--- a/docs/numenta_htm_integration.md
+++ b/docs/numenta_htm_integration.md
@@ -14,8 +14,9 @@ bringing ideas from Numenta's Thousand Brains Theory and Hierarchical Temporal M
   applies KWTA after each update[region-kwta] and the gate updates homeostatic firing rates[gate-homeo].
 
 ## 2. Incorporate Temporal Memory for Sequence Prediction
-- **Predictive activation** – Allow inactive regions to maintain a small predictive trace so they respond faster when
-  selected, analogous to HTM distal dendrites.
+- **Predictive activation** – Implemented via a per-region `predict` trace that accumulates router
+  messages while inactive so regions respond faster when later selected, analogous to HTM distal
+  dendrites.
 - **Hebbian fast weights for transitions** – Maintain a light-weight association matrix of region-to-region transitions
   and bias the gate toward frequently observed sequences. Regions already store fast weights via `state_num` and
   `state_den` buffers[region-fastweights].

--- a/ironcortex/model.py
+++ b/ironcortex/model.py
@@ -135,6 +135,8 @@ class CortexReasoner(nn.Module):
         H_cur = torch.zeros_like(H_prev)
         for r in range(self.R):
             if not bool(reg_mask[r]):
+                # Update predictive trace from messages but skip actual update
+                self.regions[r].predict(M[r])
                 self.regions[r].skip()
                 continue
             sensor_or_zero = (


### PR DESCRIPTION
## Summary
- add predictive trace to `RWKVRegionCell` allowing inactive regions to accumulate router messages
- integrate predictive trace updates in the inner reasoning loop
- document temporal memory predictive activation in Numenta integration guide

## Testing
- `black .`
- `ruff check .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch'; attempted `pip install torch` but received 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3fa6ee908325b85bc0f35aa99b9c