### PR TITLE
Initialize linear layers consistently

### DIFF
--- a/ironcortex/iron_rope.py
+++ b/ironcortex/iron_rope.py
@@ -5,7 +5,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from .utils import pad_batch, masked_mean, extract_spans
+from .utils import pad_batch, masked_mean, extract_spans, init_weights
 
 # 1) Iron RoPE: Fourier banks, rotary rotation, relative bias
 # ==========================================================
@@ -274,6 +274,7 @@ class LocalTokenMixer(nn.Module):
         self.anch_embed = nn.Parameter(
             torch.randn(3, d)
         )  # center / span_start / span_end
+        self.apply(init_weights)
 
     @torch.no_grad()
     def build_anchors(self, T: int, focus_mask: torch.Tensor, strides=(128, 32)):

--- a/ironcortex/model.py
+++ b/ironcortex/model.py
@@ -13,6 +13,7 @@ from .utils import (
     schedule_burst,
     RMSNorm,
     RegionFFState,
+    init_weights,
 )
 from .iron_rope import LocalTokenMixer
 from .heads import (
@@ -75,6 +76,7 @@ class CortexReasoner(nn.Module):
 
         # Per-region FF threshold τ
         self.reg_ff = nn.ModuleList([RegionFFState() for _ in range(self.R)])
+        self.apply(init_weights)
 
     def detach_state(self) -> None:
         """Detach stateful tensors to avoid cross-step autograd graphs."""

--- a/ironcortex/region.py
+++ b/ironcortex/region.py
@@ -1,7 +1,7 @@
 import torch
 import torch.nn as nn
 
-from .utils import RMSNorm, KWTA
+from .utils import RMSNorm, KWTA, init_weights
 from .iron_rope import rope_rotate_pairs, make_freq_bank
 
 # 5) RWKV Region Cell (with Δt skip + time rotation on v)
@@ -39,6 +39,7 @@ class RWKVRegionCell(nn.Module):
             self.register_buffer(
                 "W_time", make_freq_bank(self.m_time, 1, kind="log", base=10000.0)
             )
+        self.apply(init_weights)
 
     def decay_vec(self) -> torch.Tensor:
         return torch.sigmoid(self.decay_param).pow(2.0)  # (0,1)

--- a/ironcortex/utils.py
+++ b/ironcortex/utils.py
@@ -5,6 +5,13 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 
+def init_weights(m):
+    if isinstance(m, nn.Linear):
+        nn.init.xavier_uniform_(m.weight)
+        if m.bias is not None:
+            nn.init.zeros_(m.bias)
+
+
 # ==========================================================
 
 


### PR DESCRIPTION
## Summary
- add `init_weights` helper initializing linear layers with Xavier and zero biases
- apply `init_weights` across `CortexReasoner`, `RWKVRegionCell`, and `LocalTokenMixer` constructors for consistent initialization

## Testing
- `ruff check .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68bf4d4e5754832588579e1ae51da879