### PR TITLE
Initialize Fourier bias parameters with small random values

### DIFF
--- a/ironcortex/gate.py
+++ b/ironcortex/gate.py
@@ -121,6 +121,8 @@ class Router(nn.Module):
         )
         self.beta_cos = nn.Parameter(torch.zeros(m_reg))
         self.beta_sin = nn.Parameter(torch.zeros(m_reg))
+        nn.init.normal_(self.beta_cos, std=0.01)
+        nn.init.normal_(self.beta_sin, std=0.01)
         self.fb_scale = 1.0 / math.sqrt(m_reg)
 
     def messages(

--- a/ironcortex/iron_rope.py
+++ b/ironcortex/iron_rope.py
@@ -171,6 +171,8 @@ class IronRoPESelfAttention(nn.Module):
             else:
                 self.beta_cos = nn.Parameter(torch.zeros(self.fb_m))
                 self.beta_sin = nn.Parameter(torch.zeros(self.fb_m))
+            nn.init.normal_(self.beta_cos, std=0.01)
+            nn.init.normal_(self.beta_sin, std=0.01)
             self.fb_scale = 1.0 / math.sqrt(self.fb_m)
 
     def forward(


### PR DESCRIPTION
## Summary
- Randomly initialize Fourier bias weights for gate router and IronRoPE attention to add slight run-to-run variation.

## Testing
- `black ironcortex/gate.py ironcortex/iron_rope.py`
- `ruff check ironcortex/gate.py ironcortex/iron_rope.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68bf4d537aa0832582482ac42b078e53