### PR TITLE
Expose decay init parameter in RWKV region cells

### DIFF
--- a/ironcortex/config.py
+++ b/ironcortex/config.py
@@ -11,5 +11,6 @@ class CortexConfig:
     B_br: int = 2
     k_active: int = 8
     max_T: int = 8192
+    init_decay: float = 0.25
     # Optional dropout in goodness path (disabled by default)
     ff_dropout: bool = False

--- a/ironcortex/model.py
+++ b/ironcortex/model.py
@@ -50,7 +50,9 @@ class CortexReasoner(nn.Module):
         self.embed = SparseTokenEncoder(self.V, self.d, cfg.sdr_k)
 
         # Regions
-        self.regions = nn.ModuleList([RWKVRegionCell(self.d) for _ in range(self.R)])
+        self.regions = nn.ModuleList(
+            [RWKVRegionCell(self.d, init_decay=cfg.init_decay) for _ in range(self.R)]
+        )
 
         # Gate & Router
         self.gate = Gate(self.R, self.neighbors, io_idxs)


### PR DESCRIPTION
## Summary
- add `init_decay` parameter to RWKVRegionCell with logit initialization
- expose `init_decay` in `CortexConfig` and propagate to region creation

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68bf4d5807bc8325a09b613b21a4d453