### PR TITLE
Reduce anchor embedding init variance

### DIFF
--- a/ironcortex/iron_rope.py
+++ b/ironcortex/iron_rope.py
@@ -272,7 +272,7 @@ class LocalTokenMixer(nn.Module):
             causal=False,
         )
         self.anch_embed = nn.Parameter(
-            torch.randn(3, d)
+            torch.randn(3, d) * 0.02
         )  # center / span_start / span_end
 
     @torch.no_grad()


### PR DESCRIPTION
## Summary
- Scale anchor embedding initialization to a small variance so anchors don't overpower token embeddings at startup

## Testing
- `ruff check ironcortex/iron_rope.py`
- `black ironcortex/iron_rope.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4d5baf208325a37319f265de3166