### PR TITLE
Add hex visualizer option to Tiny Shakespeare demo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -79,5 +79,7 @@ train_tiny_shakespeare.py  # Example training script
    ```
 
    The `--seed` flag controls reproducibility. If omitted, a random seed is chosen each run.
+   Add `--visualize` to enable realtime training plots, or `--hex-vis` to display
+   region states on a hex grid.
 
 The repository is under active development. See [TODO.md](TODO.md) for planned improvements such as hex axial wiring, new token heads, and stronger verifier targets.

--- a/tests/test_train_hex_visualizer.py
+++ b/tests/test_train_hex_visualizer.py
@@ -1,0 +1,44 @@
+import random
+import torch
+import train_tiny_shakespeare as tts
+from ironcortex import CortexConfig, CortexReasoner, hex_axial_coords, hex_neighbors
+
+
+def test_train_hex_visualizer(monkeypatch):
+    torch.manual_seed(0)
+    random.seed(0)
+    cfg = CortexConfig(R=4, d=32, V=20, K_inner=2, B_br=1, k_active=2, max_T=64)
+    neighbors = hex_neighbors(cfg.R)
+    reg_coords = hex_axial_coords(cfg.R)
+    io_idxs = {"sensor": 0, "motor": cfg.R - 1}
+    device = torch.device("cpu")
+    model = CortexReasoner(neighbors, reg_coords, io_idxs, cfg).to(device)
+    data = torch.randint(0, cfg.V - 1, size=(10, 8))
+    loader = torch.utils.data.DataLoader(data, batch_size=1)
+
+    instances = []
+
+    class DummyVis:
+        def __init__(self, R):
+            self.R = R
+            self.updates: list[list[float]] = []
+            instances.append(self)
+
+        def update(self, states):
+            self.updates.append(list(states))
+
+    monkeypatch.setattr(tts, "HexStateVisualizer", DummyVis)
+
+    hparams = tts.TrainHyperParams(
+        epochs=1,
+        max_steps=2,
+        log_interval=1,
+        gen_interval=0,
+        batch_size=1,
+        seq_len=8,
+        visualize=False,
+        hex_visualize=True,
+    )
+    tts.train(model, loader, hparams, device)
+    assert instances and instances[0].updates
+    assert len(instances[0].updates[0]) == cfg.R


### PR DESCRIPTION
## Summary
- allow Tiny Shakespeare training script to optionally run a hex grid visualizer alongside standard metric plots
- expose `--visualize` and new `--hex-vis` CLI flags
- test hex visualizer integration during training

## Testing
- `black train_tiny_shakespeare.py tests/test_train_hex_visualizer.py`
- `ruff check train_tiny_shakespeare.py tests/test_train_hex_visualizer.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_68bf54c7a6b08325a2c2022bde37da60