### PR TITLE
Add model checkpoint save/load utilities

### DIFF
--- a/ironcortex/__init__.py
+++ b/ironcortex/__init__.py
@@ -26,3 +26,7 @@ from .data import (
 from .visualization import TrainVisualizer as TrainVisualizer
 from .hex_visualizer import HexStateVisualizer as HexStateVisualizer
 from .sdr import SparseTokenEncoder as SparseTokenEncoder
+from .checkpoint import (
+    save_checkpoint as save_checkpoint,
+    load_checkpoint as load_checkpoint,
+)

--- a/ironcortex/checkpoint.py
+++ b/ironcortex/checkpoint.py
@@ -1,0 +1,53 @@
+"""Checkpoint utilities for saving and loading models."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import torch
+
+from .model import CortexReasoner
+
+
+def save_checkpoint(
+    model: CortexReasoner,
+    optimizer: Optional[torch.optim.Optimizer],
+    step: int,
+    path: str | Path,
+) -> None:
+    """Save model/optimizer state and step to *path*.
+
+    Args:
+        model: Model to serialize.
+        optimizer: Optional optimizer whose state will also be saved.
+        step: Training step number to record.
+        path: Destination file path.
+    """
+
+    ckpt_path = Path(path)
+    ckpt = {
+        "model": model.state_dict(),
+        "optimizer": optimizer.state_dict() if optimizer is not None else None,
+        "step": step,
+    }
+    torch.save(ckpt, ckpt_path)
+
+
+def load_checkpoint(
+    path: str | Path,
+    model: Optional[CortexReasoner] = None,
+    optimizer: Optional[torch.optim.Optimizer] = None,
+    map_location: str | torch.device | None = None,
+) -> int:
+    """Load a checkpoint from *path* into *model* and *optimizer*.
+
+    Returns the training step stored in the checkpoint.
+    """
+
+    ckpt = torch.load(path, map_location=map_location)
+    if model is not None:
+        model.load_state_dict(ckpt["model"])
+    if optimizer is not None and ckpt.get("optimizer") is not None:
+        optimizer.load_state_dict(ckpt["optimizer"])
+    return int(ckpt.get("step", 0))

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -1,0 +1,53 @@
+import random
+
+import torch
+
+from ironcortex import (
+    CortexConfig,
+    CortexReasoner,
+    LossWeights,
+    hex_axial_coords,
+    hex_neighbors,
+    train_step,
+    save_checkpoint,
+    load_checkpoint,
+)
+
+
+def test_checkpoint_roundtrip(tmp_path):
+    torch.manual_seed(0)
+    random.seed(0)
+    cfg = CortexConfig(R=4, d=32, V=20, K_inner=2, B_br=1, k_active=2, max_T=64)
+    neighbors = hex_neighbors(cfg.R)
+    reg_coords = hex_axial_coords(cfg.R)
+    io_idxs = {"sensor": 0, "motor": cfg.R - 1}
+    device = torch.device("cpu")
+    model = CortexReasoner(neighbors, reg_coords, io_idxs, cfg).to(device)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
+    clean_tokens = torch.randint(low=0, high=cfg.V - 1, size=(1, 8), device=device)
+    lamb = LossWeights()
+    train_step(model, optimizer, clean_tokens, lamb, device)
+    ckpt = tmp_path / "ckpt.pt"
+    save_checkpoint(model, optimizer, 1, ckpt)
+
+    model2 = CortexReasoner(neighbors, reg_coords, io_idxs, cfg).to(device)
+    optimizer2 = torch.optim.AdamW(model2.parameters(), lr=1e-3)
+    step = load_checkpoint(ckpt, model2, optimizer2, map_location=device)
+    assert step == 1
+
+    for k, v in model.state_dict().items():
+        assert torch.equal(v, model2.state_dict()[k])
+
+    state1 = optimizer.state_dict()
+    state2 = optimizer2.state_dict()
+    assert state1.keys() == state2.keys()
+    assert state1["state"].keys() == state2["state"].keys()
+    for key in state1["state"]:
+        sub1 = state1["state"][key]
+        sub2 = state2["state"][key]
+        for sk in sub1:
+            v1, v2 = sub1[sk], sub2[sk]
+            if isinstance(v1, torch.Tensor):
+                assert torch.equal(v1, v2)
+            else:
+                assert v1 == v2


### PR DESCRIPTION
## Summary
- Add `save_checkpoint` and `load_checkpoint` helpers for model/optimizer state
- Wire Tiny Shakespeare training demo to periodically save and resume from checkpoints
- Export checkpoint helpers in the public package and add regression test

## Testing
- `black ironcortex/checkpoint.py train_tiny_shakespeare.py tests/test_checkpoint.py ironcortex/__init__.py`
- `ruff check .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install --quiet torch --index-url https://download.pytorch.org/whl/cpu` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_68bf563f7b188325a9cf1a10f1d485ed