### PR TITLE
Ensure hex visualizer starts in Tiny Shakespeare demo

### DIFF
--- a/tests/test_train_hex_visualizer.py
+++ b/tests/test_train_hex_visualizer.py
@@ -31,8 +31,8 @@ def test_train_hex_visualizer(monkeypatch):
 
     hparams = tts.TrainHyperParams(
         epochs=1,
-        max_steps=2,
-        log_interval=1,
+        max_steps=1,
+        log_interval=10,
         gen_interval=0,
         batch_size=1,
         seq_len=8,

--- a/train_tiny_shakespeare.py
+++ b/train_tiny_shakespeare.py
@@ -74,6 +74,8 @@ def train(
     if hparams.hex_visualize:
         try:
             hex_vis = HexStateVisualizer(R=model.cfg.R)
+            gains = torch.sigmoid(model.gate.gain_ema.detach()).tolist()
+            hex_vis.update(gains)
         except Exception as e:  # pragma: no cover - visualization optional
             print(f"hex visualization disabled: {e}")
     prompt_ids = torch.tensor(


### PR DESCRIPTION
## Summary
- Initialize HexStateVisualizer with current gate gains so the window appears immediately
- Adjust training test to cover visualization startup even before logging

## Testing
- `ruff check .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68bf5a5cb90883258a8f7d132c31582b