### PR TITLE
fix: ensure GUI backend for visualizations

### DIFF
--- a/ironcortex/visualization.py
+++ b/ironcortex/visualization.py
@@ -10,13 +10,31 @@ from dataclasses import dataclass
 from typing import Dict, Iterable, Mapping
 
 import matplotlib
-import matplotlib.pyplot as plt
+
+
+def _ensure_gui_backend() -> None:
+    """Switch to a GUI backend if running under an inline backend."""
+
+    backend = matplotlib.get_backend().lower()
+    if "matplotlib_inline" in backend:
+        for candidate in ("TkAgg", "QtAgg", "GTK3Agg"):
+            try:  # pragma: no cover - backend availability depends on system
+                matplotlib.use(candidate)
+                break
+            except Exception:  # pragma: no cover - fallback to default backend
+                continue
+
+
+_ensure_gui_backend()
+import matplotlib.pyplot as plt  # noqa: E402
 
 
 def _is_interactive_backend() -> bool:
     """Return True if matplotlib is using an interactive backend."""
 
     backend = matplotlib.get_backend().lower()
+    if "matplotlib_inline" in backend:
+        return False
     return backend not in {"agg", "pdf", "ps", "svg", "cairo"}
 
 

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,4 +1,8 @@
-from ironcortex.visualization import TrainVisualizer
+import matplotlib
+
+matplotlib.use("Agg")
+
+from ironcortex.visualization import TrainVisualizer, _is_interactive_backend
 
 
 def test_visualizer_update():
@@ -22,3 +26,10 @@ def test_visualizer_update():
         "tau_mean": 0.2,
     }
     viz.update(1, metrics, eval_metrics)
+
+
+def test_inline_backend_detection(monkeypatch):
+    monkeypatch.setattr(
+        matplotlib, "get_backend", lambda: "module://matplotlib_inline.backend_inline"
+    )
+    assert not _is_interactive_backend()


### PR DESCRIPTION
## Summary
- ensure Matplotlib switches to a GUI backend when running under the inline backend so visual windows appear in VSCode
- treat inline backends as non-interactive and add regression test

## Testing
- `black ironcortex/visualization.py tests/test_visualization.py`
- `ruff check ironcortex/visualization.py tests/test_visualization.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install matplotlib==3.8.2` *(fails: Could not find a version that satisfies the requirement matplotlib==3.8.2)*
- `pip install torch --extra-index-url https://download.pytorch.org/whl/cpu` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5c2392588325ad390ba846a3e141