### PR TITLE
Improve GUI backend handling for visualizers

### DIFF
--- a/ironcortex/hex_visualizer.py
+++ b/ironcortex/hex_visualizer.py
@@ -7,13 +7,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Sequence
+import warnings
 
 import numpy as np
+from .visualization import _is_interactive_backend
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d.art3d import Poly3DCollection
 
 from .wiring import hex_axial_coords
-from .visualization import _is_interactive_backend
 
 
 @dataclass
@@ -46,6 +47,12 @@ class HexStateVisualizer:
                 plt.show(block=False)
             except Exception:
                 self.interactive = False
+        else:  # pragma: no cover - used for user feedback in headless setups
+            warnings.warn(
+                "Matplotlib is using a non-interactive backend; hex state"
+                " plots will not be displayed.",
+                RuntimeWarning,
+            )
 
     def _axial_to_cart(self, q: float, r: float) -> tuple[float, float]:
         x = self.size * np.sqrt(3) * (q + r / 2)

--- a/ironcortex/visualization.py
+++ b/ironcortex/visualization.py
@@ -10,13 +10,20 @@ from dataclasses import dataclass
 from typing import Dict, Iterable, Mapping
 
 import matplotlib
+import warnings
 
 
 def _ensure_gui_backend() -> None:
-    """Switch to a GUI backend if running under an inline backend."""
+    """Switch to a GUI backend when running headless."""
 
     backend = matplotlib.get_backend().lower()
-    if "matplotlib_inline" in backend:
+    if "matplotlib_inline" in backend or backend in {
+        "agg",
+        "pdf",
+        "ps",
+        "svg",
+        "cairo",
+    }:
         for candidate in ("TkAgg", "QtAgg", "GTK3Agg"):
             try:  # pragma: no cover - backend availability depends on system
                 matplotlib.use(candidate)
@@ -82,6 +89,12 @@ class TrainVisualizer:
                 plt.show(block=False)
             except Exception:
                 self.interactive = False
+        else:  # pragma: no cover - used for user feedback in headless setups
+            warnings.warn(
+                "Matplotlib is using a non-interactive backend; training curves"
+                " will not be displayed.",
+                RuntimeWarning,
+            )
 
     def update(
         self, step: int, metrics: Mapping[str, float], eval_metrics: Mapping[str, float]


### PR DESCRIPTION
## Summary
- ensure non-interactive backends attempt to switch to GUI backends
- warn users when figures can't be shown due to backend limitations
- import visualization utilities before pyplot in HexStateVisualizer to allow backend switching

## Testing
- `pytest tests/test_visualization.py::test_visualizer_update -q` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_68bf5ece3c988325b5f95cbbeebdaa1b