### PR TITLE
fix: support older matplotlib ArtistList

### DIFF
--- a/ironcortex/hex_visualizer.py
+++ b/ironcortex/hex_visualizer.py
@@ -75,7 +75,10 @@ class HexStateVisualizer:
         mapped from black (0) to matrix green (1).
         """
 
-        self.ax.collections.clear()
+        try:
+            self.ax.collections.clear()
+        except AttributeError:
+            del self.ax.collections[:]
         for (q, r), s in zip(self.coords, states):
             x, y = self._axial_to_cart(q, r)
             outer = Poly3DCollection(


### PR DESCRIPTION
## Summary
- handle ArtistList without `.clear` in HexStateVisualizer

## Testing
- `ruff check .`
- `black ironcortex/hex_visualizer.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68bf60eaebcc8325a18d9f96d02f0b0e