### PR TITLE
Fix Axes3D collections clearing

### DIFF
--- a/ironcortex/hex_visualizer.py
+++ b/ironcortex/hex_visualizer.py
@@ -89,11 +89,11 @@ class HexStateVisualizer:
             self.ax.collections.clear()
         except Exception:
             # Some matplotlib backends expose "collections" as an ArtistList
-            # whose ``clear``/deletion operations raise ``TypeError``. Replace
-            # the container wholesale to avoid these issues. ``ArtistList``
-            # requires constructor arguments, so instantiate a plain list
-            # instead of ``type(self.ax.collections)()``.
-            self.ax.collections = []
+            # that lacks a ``clear`` method and cannot be reassigned (read-only
+            # property). In those cases remove items in-place to avoid
+            # triggering ``AttributeError: property 'collections' has no
+            # setter``.
+            del self.ax.collections[:]
         for (q, r), s in zip(self.coords, states):
             x, y = self._axial_to_cart(q, r)
             outer = Poly3DCollection(


### PR DESCRIPTION
## Summary
- avoid assigning to read-only `Axes3D.collections` in hex visualizer by clearing in-place

## Testing
- `ruff check .`
- `black ironcortex/hex_visualizer.py`
- `pytest` *(fails: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68bf65f2dbc88325a73f867122cde738