### PR TITLE
feat: add adaptive filter feature flags

### DIFF
--- a/ironcortex/config.py
+++ b/ironcortex/config.py
@@ -14,3 +14,8 @@ class CortexConfig:
     init_decay: float = 0.25
     # Optional dropout in goodness path (disabled by default)
     ff_dropout: bool = False
+    enable_adaptive_filter_dynamics: bool = False
+    enable_precision_routed_messages: bool = False
+    enable_radial_tangential_updates: bool = False
+    enable_afa_attention: bool = False
+    enable_ff_energy_alignment: bool = False

--- a/ironcortex/gate.py
+++ b/ironcortex/gate.py
@@ -100,11 +100,19 @@ class Router(nn.Module):
     in the transform helps the router "feel" the hex geometry.
     """
 
-    def __init__(self, neighbor_indices: List[List[int]], d: int, R: int):
+    def __init__(
+        self,
+        neighbor_indices: List[List[int]],
+        d: int,
+        R: int,
+        *,
+        enable_precision_routed_messages: bool = False,
+    ):
         super().__init__()
         self.R = R
         self.d = d
         self.neighbors = neighbor_indices
+        self.enable_precision_routed_messages = enable_precision_routed_messages
 
         # Edge transforms
         edges = {}
@@ -133,6 +141,9 @@ class Router(nn.Module):
         H: [R,d], reg_mask_prev: [R] bool, reg_coords: [R,2]
         Returns M: [R,d]
         """
+        if self.enable_precision_routed_messages:
+            # Placeholder: precision-weighted routing will augment this aggregation
+            pass
         device = H.device
         M = torch.zeros(self.R, self.d, device=device)
         # Prepare coordinate tensors for bias

--- a/ironcortex/training.py
+++ b/ironcortex/training.py
@@ -171,7 +171,11 @@ def train_step(
         y_neg = F.softmax(logits_neg.detach(), dim=-1)
         E_pos = model.verify(motor_pos.detach(), y_pos)
         E_neg = model.verify(motor_neg.detach(), y_neg)
-        verifier_loss = ff_energy_loss(E_pos, E_neg, tau=0.0)
+        if model.cfg.enable_ff_energy_alignment:
+            # Placeholder for future energy-alignment modifications
+            verifier_loss = ff_energy_loss(E_pos, E_neg, tau=0.0)
+        else:
+            verifier_loss = ff_energy_loss(E_pos, E_neg, tau=0.0)
         total_E_pos += float(E_pos.detach().mean().item())
         total_E_neg += float(E_neg.detach().mean().item())
 


### PR DESCRIPTION
## Summary
- add configuration flags for adaptive filter milestones
- expose new flags through Tiny Shakespeare CLI
- scaffold region, router, and training code paths behind flags

## Testing
- `black ironcortex/config.py ironcortex/model.py ironcortex/gate.py ironcortex/region.py ironcortex/training.py train_tiny_shakespeare.py`
- `ruff check ironcortex/config.py ironcortex/model.py ironcortex/gate.py ironcortex/region.py ironcortex/training.py train_tiny_shakespeare.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68c051aeb34c8325ae1b0890a82d94d3