### PR TITLE
Implement radial–tangential RWKV state updates

### DIFF
--- a/AFA.md
+++ b/AFA.md
@@ -116,26 +116,26 @@ This document outlines the milestones and tasks for integrating Adaptive Filter 
 
 ### 3.1 Directional Processing
 
-* [ ] After computing region output vector `y`:
+* [x] After computing region output vector `y`:
 
   * `norm = y.norm(2, dim=-1, keepdim=True) + eps`
   * `dir = y / norm`
-* [ ] Apply output transform to **direction only**:
+* [x] Apply output transform to **direction only**:
 
   * `h_dir = o_lin(dir)`
   * Compose with magnitude:
 
     * Option A: `h = x + norm * h_dir`
-    * Option B: EMA magnitude `radius = ρ*radius + (1-ρ)*norm` and `h = x + radius * h_dir`.
+    * [x] Option B: EMA magnitude `radius = ρ*radius + (1-ρ)*norm` and `h = x + radius * h_dir`.
 
 ### 3.2 Precision on Magnitude (Optional)
 
-* [ ] Track `radius_var` (1‑D Kalman on norm) and update radial component with small gain.
+* [x] Track `radius_var` (1‑D Kalman on norm) and update radial component with small gain.
 
 ### Tests/Acceptance
 
-* [ ] Unit test: norm of `dir` \~ 1, finite grads.
-* [ ] Radial EMA reduces spikes on synthetic bursts.
+* [x] Unit test: norm of `dir` \~ 1, finite grads.
+* [x] Radial EMA reduces spikes on synthetic bursts.
 
 ---
 


### PR DESCRIPTION
## Summary
- split region updates into magnitude and direction with EMA-smoothed radius and Kalman precision
- track radial statistics and expose last direction for testing
- add coverage for direction norm and spike smoothing

## Testing
- `black ironcortex/region.py tests/test_rwkv_region.py`
- `ruff check .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch --index-url https://download.pytorch.org/whl/cpu` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_68c0577e1b748325a381ba65acfd2ea1