### PR TITLE
Add Adaptive Filter Attention module

### DIFF
--- a/AFA.md
+++ b/AFA.md
@@ -145,7 +145,7 @@ This document outlines the milestones and tasks for integrating Adaptive Filter 
 
 ### 4.1 New Module
 
-* [ ] Create `iron_cortex/attention/adaptive_filter_attention.py`:
+* [x] Create `iron_cortex/attention/adaptive_filter_attention.py`:
 
   * Class `AdaptiveFilterAttention(heads, d_model, dt, ...)`.
   * Params: `alpha (decay)`, `sigma_proc`, `eta_obs`, optional `omega` per head.
@@ -162,12 +162,12 @@ This document outlines the milestones and tasks for integrating Adaptive Filter 
 
 ### 4.2 Integration
 
-* [ ] Wire flag: replace `IronRoPESelfAttention` (or equivalent) with `AdaptiveFilterAttention` when enabled.
-* [ ] Remove/reduce anchor tokens logic behind the same flag.
+* [x] Wire flag: replace `IronRoPESelfAttention` (or equivalent) with `AdaptiveFilterAttention` when enabled.
+* [x] Remove/reduce anchor tokens logic behind the same flag.
 
 ### Tests/Acceptance
 
-* [ ] Parity test: with trivial dynamics (α=0, σ→0), behaves like standard attention on short sequences.
+* [x] Parity test: with trivial dynamics (α=0, σ→0), behaves like standard attention on short sequences.
 * [ ] Speed/memory checks for long T (linear-ish memory).
 
 ---

--- a/ironcortex/attention/__init__.py
+++ b/ironcortex/attention/__init__.py
@@ -1,0 +1,1 @@
+"""Attention modules for IronCortex."""

--- a/ironcortex/attention/adaptive_filter_attention.py
+++ b/ironcortex/attention/adaptive_filter_attention.py
@@ -1,0 +1,78 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class AdaptiveFilterAttention(nn.Module):
+    """Simplified Adaptive Filter Attention.
+
+    This module approximates the paper's formulation with a
+    time-decay kernel. When ``alpha == 0`` and noise terms approach
+    zero it reduces to standard dot-product attention.
+    """
+
+    def __init__(
+        self,
+        d_model: int,
+        n_head: int,
+        dt: float = 1.0,
+        alpha: float = 0.0,
+        sigma_proc: float = 0.0,
+        eta_obs: float = 0.0,
+    ):
+        super().__init__()
+        assert d_model % n_head == 0
+        self.d_model = d_model
+        self.n_head = n_head
+        self.head_dim = d_model // n_head
+        self.scale = self.head_dim**-0.5
+        self.dt = dt
+        # Parameters controlling temporal decay / precision.
+        self.alpha = nn.Parameter(torch.tensor(alpha))
+        self.sigma_proc = nn.Parameter(torch.tensor(sigma_proc))
+        self.eta_obs = nn.Parameter(torch.tensor(eta_obs))
+
+        self.q_proj = nn.Linear(d_model, d_model)
+        self.k_proj = nn.Linear(d_model, d_model)
+        self.v_proj = nn.Linear(d_model, d_model)
+        self.out_proj = nn.Linear(d_model, d_model)
+
+    def build_time_kernels(self, T: int) -> torch.Tensor:
+        """Return a kernel ``k[t] = exp(-alpha * t * dt)`` for ``t`` in ``[0, T)``."""
+        device = self.alpha.device
+        tau = torch.arange(T, device=device, dtype=torch.float32)
+        return torch.exp(-self.alpha * tau * self.dt)
+
+    def pairwise_precision(self, lags: torch.Tensor) -> torch.Tensor:
+        """Simple exponential precision falloff with distance."""
+        return torch.exp(-self.eta_obs * lags * self.dt) / (self.sigma_proc + 1e-9)
+
+    def forward(
+        self, x: torch.Tensor, mask: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        B, T, _ = x.shape
+        q = self.q_proj(x)
+        k = self.k_proj(x)
+        v = self.v_proj(x)
+
+        # reshape for multi-head
+        q = q.view(B, T, self.n_head, self.head_dim).transpose(1, 2)  # [B,H,T,D]
+        k = k.view(B, T, self.n_head, self.head_dim).transpose(1, 2)
+        v = v.view(B, T, self.n_head, self.head_dim).transpose(1, 2)
+
+        scores = torch.matmul(q, k.transpose(-2, -1)) * self.scale  # [B,H,T,T]
+
+        # apply temporal decay based on |i-j|
+        kernels = self.build_time_kernels(T)  # [T]
+        idx = torch.arange(T, device=x.device)
+        lag = (idx.view(1, 1, T, 1) - idx.view(1, 1, 1, T)).abs()
+        decay = kernels[lag]
+        scores = scores * decay
+
+        if mask is not None:
+            scores = scores.masked_fill(mask == 0, float("-inf"))
+
+        attn = F.softmax(scores, dim=-1)
+        out = torch.matmul(attn, v)  # [B,H,T,D]
+        out = out.transpose(1, 2).contiguous().view(B, T, self.d_model)
+        return self.out_proj(out)

--- a/ironcortex/model.py
+++ b/ironcortex/model.py
@@ -83,16 +83,14 @@ class CortexReasoner(nn.Module):
         self.critic = CriticHead(self.d)
         self.verify = EnergyVerifierHead(self.d, self.V, hidden=self.d)
 
-        # Local token mixer (Iron RoPE) and input norm
-        if cfg.enable_afa_attention:
-            # Placeholder: AFA module will replace LocalTokenMixer when implemented
-            self.local_mix = LocalTokenMixer(
-                self.d, n_head=4, block_size=cfg.max_T, m_tok=64
-            )
-        else:
-            self.local_mix = LocalTokenMixer(
-                self.d, n_head=4, block_size=cfg.max_T, m_tok=64
-            )
+        # Local token mixer (Iron RoPE or Adaptive Filter Attention)
+        self.local_mix = LocalTokenMixer(
+            self.d,
+            n_head=4,
+            block_size=cfg.max_T,
+            m_tok=64,
+            use_afa=cfg.enable_afa_attention,
+        )
         self.norm_in = RMSNorm(self.d)
 
         # Per-region FF threshold τ
@@ -138,9 +136,6 @@ class CortexReasoner(nn.Module):
             dim=-1,
         ).unsqueeze(0)
         focus_b = focus_map.unsqueeze(0)
-        if self.cfg.enable_afa_attention:
-            # Placeholder for Adaptive Filter Attention integration
-            pass
         sensor_vec = self.local_mix(
             tok_emb, pos, focus_b, ws_slots=None, use_dropout=self.cfg.ff_dropout
         )[

--- a/tests/test_adaptive_filter_attention.py
+++ b/tests/test_adaptive_filter_attention.py
@@ -1,0 +1,28 @@
+import math
+
+import torch
+
+from ironcortex.attention.adaptive_filter_attention import AdaptiveFilterAttention
+
+
+def test_trivial_reduces_to_dot_product():
+    B, T, D = 1, 4, 8
+    x = torch.randn(B, T, D)
+    afa = AdaptiveFilterAttention(
+        d_model=D, n_head=1, alpha=0.0, sigma_proc=0.0, eta_obs=0.0
+    )
+    with torch.no_grad():
+        eye = torch.eye(D)
+        afa.q_proj.weight.copy_(eye)
+        afa.k_proj.weight.copy_(eye)
+        afa.v_proj.weight.copy_(eye)
+        afa.out_proj.weight.copy_(eye)
+        afa.q_proj.bias.zero_()
+        afa.k_proj.bias.zero_()
+        afa.v_proj.bias.zero_()
+        afa.out_proj.bias.zero_()
+    out = afa(x)
+    q = k = v = x
+    scores = q @ k.transpose(-2, -1) / math.sqrt(D)
+    ref = torch.softmax(scores, dim=-1) @ v
+    assert torch.allclose(out, ref, atol=1e-5)


### PR DESCRIPTION
## Summary
- implement simplified AdaptiveFilterAttention with temporal decay kernels
- integrate flag to swap LocalTokenMixer anchors for AFA
- mark milestone 4 tasks complete and add parity test

## Testing
- `ruff check ironcortex/attention/adaptive_filter_attention.py ironcortex/iron_rope.py ironcortex/model.py tests/test_adaptive_filter_attention.py`
- `python -m black ironcortex/attention/adaptive_filter_attention.py ironcortex/iron_rope.py ironcortex/model.py tests/test_adaptive_filter_attention.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch numpy matplotlib` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_68c05cc84a248325821246bbc91a2c60