### PR TITLE
feat: integrate ff energy alignment

### DIFF
--- a/AFA.md
+++ b/AFA.md
@@ -178,25 +178,25 @@ This document outlines the milestones and tasks for integrating Adaptive Filter 
 
 ### 5.1 Surprise/Energy per Region
 
-* [ ] After update, compute `surprise = (resid.pow(2) * state_prec).sum()` per region.
-* [ ] Maintain `surprise_ema = β * surprise_ema + (1-β) * surprise`.
-* [ ] Expose `surprise_ema` for logging and FF integration.
+* [x] After update, compute `surprise = (resid.pow(2) * state_prec).sum()` per region.
+* [x] Maintain `surprise_ema = β * surprise_ema + (1-β) * surprise`.
+* [x] Expose `surprise_ema` for logging and FF integration.
 
 ### 5.2 Goodness Adjustment
 
-* [ ] In FF goodness (positive phase), incorporate **low energy == high goodness**:
+* [x] In FF goodness (positive phase), incorporate **low energy == high goodness**:
 
   * `region_goodness = base_goodness - λ * surprise_ema`
   * λ via config.
 
 ### 5.3 Verifier Features
 
-* [ ] Aggregate **attention energy** per token (e.g., `-mean(log w_i)`).
-* [ ] Feed as auxiliary input to `EnergyVerifierHead` (or regularizer term).
+* [x] Aggregate **attention energy** per token (e.g., `-mean(log w_i)`).
+* [x] Feed as auxiliary input to `EnergyVerifierHead` (or regularizer term).
 
 ### 5.4 Adaptive τ (Threshold)
 
-* [ ] In region FF state, modulate `τ` by mean precision:
+* [x] In region FF state, modulate `τ` by mean precision:
 
   * `τ_target = g_pos_mean + κ * (mean(state_prec) - target_prec)`
   * `τ = (1-α)*τ + α*τ_target`.

--- a/ironcortex/config.py
+++ b/ironcortex/config.py
@@ -19,3 +19,6 @@ class CortexConfig:
     enable_radial_tangential_updates: bool = False
     enable_afa_attention: bool = False
     enable_ff_energy_alignment: bool = False
+    surprise_lambda: float = 0.0
+    tau_kappa: float = 0.0
+    tau_target_prec: float = 1.0

--- a/ironcortex/evaluation.py
+++ b/ironcortex/evaluation.py
@@ -34,7 +34,7 @@ def evaluate_perplexity(
     ctx = tokens[:, :-1]
     targets = tokens[:, -1]
     focus = torch.zeros(B, T - 1, dtype=torch.bool, device=device)
-    _, _, logits, _ = model.reasoning_loop_batch(ctx, model.cfg.K_inner, focus)
+    _, _, logits, _, _ = model.reasoning_loop_batch(ctx, model.cfg.K_inner, focus)
     log_probs = F.log_softmax(logits, dim=-1)
     ce = F.nll_loss(log_probs, targets, reduction="mean").item()
     ppl = float(math.exp(ce))

--- a/ironcortex/generation.py
+++ b/ironcortex/generation.py
@@ -63,7 +63,9 @@ def generate(
             ):
                 break
 
-        energy = model.verify(motor_state, probs)
+        energy = model.verify(
+            motor_state, probs, attn_energy=model.local_mix.last_energy
+        )
         if (best_energy is None) or (energy < best_energy):
             best_energy = energy
             best_tokens = tokens.clone()


### PR DESCRIPTION
## Summary
- track per-region surprise and EMA to influence goodness
- feed attention energy into EnergyVerifierHead and training
- adapt forward-forward thresholds using state precision

## Testing
- `ruff check .`
- `pytest` *(fails: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68c05ffdf85083259886133724cef15d