### PR TITLE
Implement Milestone 6 telemetry and testing

### DIFF
--- a/AFA.md
+++ b/AFA.md
@@ -212,12 +212,12 @@ This document outlines the milestones and tasks for integrating Adaptive Filter 
 
 ### 6.1 Telemetry
 
-* [ ] Log per‑region: `state_var/prec`, `surprise_ema`, routing weights stats (mean, entropy).
-* [ ] Log AFA: `alpha`, `sigma_proc`, `eta_obs`, kernel norms.
+* [x] Log per‑region: `state_var/prec`, `surprise_ema`, routing weights stats (mean, entropy).
+* [x] Log AFA: `alpha`, `sigma_proc`, `eta_obs`, kernel norms.
 
 ### 6.2 Unit Tests
 
-* [ ] RNG‑seeded checks for:
+* [x] RNG‑seeded checks for:
 
   * No NaNs/Inf under stress.
   * Grad flow through all new branches.
@@ -225,8 +225,8 @@ This document outlines the milestones and tasks for integrating Adaptive Filter 
 
 ### 6.3 Benchmarks
 
-* [ ] Micro‑benchmarks: before/after runtime & memory on synthetic long sequences.
-* [ ] Quality proxy: noise‑rejection toy task (AFA on/off).
+* [x] Micro‑benchmarks: before/after runtime & memory on synthetic long sequences.
+* [x] Quality proxy: noise‑rejection toy task (AFA on/off).
 
 ---
 

--- a/ironcortex/model.py
+++ b/ironcortex/model.py
@@ -109,6 +109,19 @@ class CortexReasoner(nn.Module):
         for region in getattr(self, "regions", []):
             region.detach_state()
 
+    def telemetry(self) -> dict:
+        """Collect telemetry from regions, router, and attention modules."""
+        reg_stats = [r.telemetry() for r in self.regions]
+        metrics = {
+            "regions": reg_stats,
+            "routing_weight_mean": self.router.last_weight_mean,
+            "routing_weight_entropy": self.router.last_weight_entropy,
+        }
+        attn = getattr(self.local_mix, "attn", None)
+        if attn is not None and hasattr(attn, "telemetry"):
+            metrics["afa"] = attn.telemetry()
+        return metrics
+
     def region_input(
         self, r: int, x_sensor: torch.Tensor, msg: torch.Tensor
     ) -> torch.Tensor:

--- a/ironcortex/region.py
+++ b/ironcortex/region.py
@@ -117,6 +117,15 @@ class RWKVRegionCell(nn.Module):
         self.radius_var = self.radius_var.detach()
         self.surprise_ema = self.surprise_ema.detach()
 
+    def telemetry(self) -> dict:
+        """Return lightweight telemetry for logging."""
+        prec = (self.state_var + 1e-9).reciprocal()
+        return {
+            "state_var": float(self.state_var.mean().detach()),
+            "state_prec": float(prec.mean().detach()),
+            "surprise_ema": float(self.surprise_ema.detach()),
+        }
+
     def step(self, x_in: torch.Tensor, step_pos_scalar: float) -> torch.Tensor:
         """One RWKV region update.
 

--- a/tests/test_milestone6.py
+++ b/tests/test_milestone6.py
@@ -1,0 +1,85 @@
+import torch
+
+from ironcortex import (
+    CortexConfig,
+    CortexReasoner,
+    LossWeights,
+    hex_axial_coords,
+    hex_neighbors,
+    train_step,
+)
+from ironcortex.gate import Router
+from ironcortex.attention.adaptive_filter_attention import AdaptiveFilterAttention
+from ironcortex.evaluation import runtime_memory_benchmark, noise_rejection_benchmark
+
+
+def test_no_nans_grad_flow_and_telemetry():
+    torch.manual_seed(0)
+    cfg = CortexConfig(
+        R=3,
+        d=8,
+        V=16,
+        K_inner=1,
+        B_br=1,
+        k_active=2,
+        max_T=16,
+        enable_adaptive_filter_dynamics=True,
+        enable_precision_routed_messages=True,
+        enable_radial_tangential_updates=True,
+        enable_afa_attention=True,
+        enable_ff_energy_alignment=True,
+    )
+    neighbors = hex_neighbors(cfg.R)
+    reg_coords = hex_axial_coords(cfg.R)
+    io_idxs = {"sensor": 0, "motor": cfg.R - 1}
+    device = torch.device("cpu")
+    model = CortexReasoner(neighbors, reg_coords, io_idxs, cfg).to(device)
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+    tokens = torch.randint(0, cfg.V - 1, (1, 4), device=device)
+    weights = LossWeights()
+    metrics = train_step(model, optimizer, tokens, weights, device)
+    for v in metrics.values():
+        assert torch.isfinite(torch.tensor(v))
+    for p in model.parameters():
+        if p.grad is not None:
+            assert torch.isfinite(p.grad).all()
+    telem = model.telemetry()
+    assert "regions" in telem and len(telem["regions"]) == cfg.R
+    assert "routing_weight_mean" in telem
+
+
+def test_edge_cases_router_and_attention():
+    torch.manual_seed(0)
+    router = Router([[]], d=4, R=1, enable_precision_routed_messages=True)
+    H = torch.randn(1, 4)
+    mask = torch.zeros(1, dtype=torch.bool)
+    coords = torch.zeros(1, 2)
+    out = router.messages(H, mask, coords)
+    assert torch.isfinite(out).all()
+    attn = AdaptiveFilterAttention(d_model=8, n_head=2)
+    x = torch.randn(1, 4, 8)
+    mask = torch.zeros(1, 4, 4)
+    y = attn(x, mask=mask)
+    assert torch.isfinite(y).all()
+
+
+def test_benchmarks_run():
+    torch.manual_seed(0)
+    cfg = CortexConfig(
+        R=2,
+        d=8,
+        V=16,
+        K_inner=1,
+        B_br=1,
+        k_active=1,
+        max_T=16,
+        enable_afa_attention=True,
+    )
+    neighbors = hex_neighbors(cfg.R)
+    reg_coords = hex_axial_coords(cfg.R)
+    io_idxs = {"sensor": 0, "motor": 1}
+    model = CortexReasoner(neighbors, reg_coords, io_idxs, cfg)
+    bench = runtime_memory_benchmark(model, seq_len=4, device=torch.device("cpu"))
+    assert "runtime_s" in bench and "memory_bytes" in bench
+    quality = noise_rejection_benchmark(seq_len=8, d=8)
+    assert quality["mse_std"] >= 0 and quality["mse_afa"] >= 0


### PR DESCRIPTION
## Summary
- add telemetry collectors for region variance/precision, router weight stats, and AFA parameters
- provide runtime/memory and noise-rejection benchmarks
- stress tests covering NaN/Inf safety, gradient flow, and edge cases

## Testing
- `ruff check ironcortex tests/test_milestone6.py`
- `black ironcortex/region.py ironcortex/gate.py ironcortex/attention/adaptive_filter_attention.py ironcortex/model.py ironcortex/evaluation.py tests/test_milestone6.py`
- `pytest` *(failed: ModuleNotFoundError: No module named 'torch'; attempted `pip install torch` but proxy returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c06bfaea1c83259dfee7752298e96d