### PR TITLE
Vectorize router message passing and add transform modes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -46,29 +46,29 @@ Objective: Remove per-sample Python loops; add batched inner loop.
 ### Rollback
 - Keep old path behind use_batched_reasoning=False.
 
-## Milestone 2 — Router Refactor: Vectorized, Robust, Lean
+## Milestone 2 — Router Refactor: Vectorized, Robust, Lean ✅
 
 Objective: Replace nested loops with batched message passing; fuse robust weights; reduce transform params.
 
 ### Tasks
-- Vectorized aggregation interface
+- [x] Vectorized aggregation interface
   - RG: class Router, def messages|aggregate
   - Create Router.aggregate(H_prev, active_mask) returning M (messages per region).
   - Build tensors of all active edges:
     - src_idx, dst_idx (shape [E])
   - Gather H_prev[src_idx] → [E, d].
-- Query/Key precompute
+- [x] Query/Key precompute
   - Compute Q[dst] once; K[src] once (shared or per edge‑type).
   - scores = (Q[dst_idx] * K[src_idx]).sum(-1) / sqrt(d) → [E].
-- Robust weighting (fused)
+- [x] Robust weighting (fused)
   - Compute messages: msg = W_edge[src->dst](H_prev[src]) + FourierBias.
   - Residual: resid = msg - H_prev[dst_idx].
   - Mahalanobis: mah = (resid.pow(2) * P_edge[src->dst]).sum(-1).clamp_max(MAX_EXP/0.5).
   - Fused exponent: logw = scores - 0.5 * mah; normalize with scatter_logsumexp per destination; w = exp(logw - logZ[dst_idx]).
-- Scatter-add aggregation
+- [x] Scatter-add aggregation
   - M = zeros([R,d]); scatter_add(M[dst_idx], w.unsqueeze(-1)*msg).
   - Handle empty destinations: if no incoming edge, keep zeros.
-- Parameter reduction modes
+- [x] Parameter reduction modes
   - Add CFG.edge_transform_mode:
     - per_edge (current)
     - by_direction: share W_edge for each of 6 hex directions; build a direction map upfront.

--- a/ironcortex/config.py
+++ b/ironcortex/config.py
@@ -19,6 +19,8 @@ class CortexConfig:
     enable_radial_tangential_updates: bool = False
     enable_afa_attention: bool = False
     enable_ff_energy_alignment: bool = False
+    router_vectorized: bool = True
+    edge_transform_mode: str = "per_edge"
     enable_energy_verifier: bool = True
     enable_forward_forward: bool = True
     debug_metrics_every_n_steps: int = 0

--- a/ironcortex/gate.py
+++ b/ironcortex/gate.py
@@ -7,7 +7,7 @@ import torch.nn.functional as F
 
 from .utils import nms_topk
 from .iron_rope import make_freq_bank, relative_fourier_bias
-from .constants import EPS_DIV, EPS_LOG
+from .constants import EPS_DIV, EPS_LOG, MAX_EXP
 
 # 4) Gate (compute allocation) & Router (message passing with Fourier bias)
 # ==========================================================
@@ -110,30 +110,58 @@ class Router(nn.Module):
         R: int,
         *,
         enable_precision_routed_messages: bool = False,
+        vectorized: bool = True,
+        edge_transform_mode: str = "per_edge",
     ):
         super().__init__()
         self.R = R
         self.d = d
         self.neighbors = neighbor_indices
         self.enable_precision_routed_messages = enable_precision_routed_messages
+        self.vectorized = vectorized
+        self.edge_transform_mode = edge_transform_mode
 
-        # Edge transforms
-        edges = {}
+        # Precompute edge indices and keys
+        src_idx, dst_idx, keys = [], [], []
         for r in range(R):
             for s in self.neighbors[r]:
-                edges[f"{s}->{r}"] = nn.Linear(d, d, bias=False)
-        self.W_edge = nn.ModuleDict(edges)
+                src_idx.append(s)
+                dst_idx.append(r)
+                keys.append(f"{s}->{r}")
+        self.register_buffer("src_idx", torch.tensor(src_idx, dtype=torch.long))
+        self.register_buffer("dst_idx", torch.tensor(dst_idx, dtype=torch.long))
+        self.edge_keys = keys
+
+        # Edge/message transform modes
+        if edge_transform_mode == "per_edge":
+            self.W_edge = nn.ModuleDict({k: nn.Linear(d, d, bias=False) for k in keys})
+            self.key_lin = nn.ModuleDict({k: nn.Linear(d, d, bias=False) for k in keys})
+            self.raw_P_edge = nn.ParameterDict(
+                {k: nn.Parameter(torch.zeros(d)) for k in keys}
+            )
+        elif edge_transform_mode == "by_direction":
+            self.W_dir = nn.ModuleList([nn.Linear(d, d, bias=False) for _ in range(6)])
+            self.key_lin_dir = nn.ModuleList(
+                [nn.Linear(d, d, bias=False) for _ in range(6)]
+            )
+            self.raw_P_dir = nn.ParameterList(
+                [nn.Parameter(torch.zeros(d)) for _ in range(6)]
+            )
+        elif edge_transform_mode == "factorized":
+            self.U = nn.Linear(d, d, bias=False)
+            self.V = nn.Linear(d, d, bias=False)
+            self.w_edge = nn.ParameterDict(
+                {k: nn.Parameter(torch.ones(d)) for k in keys}
+            )
+            self.key_lin = nn.ModuleDict({k: nn.Linear(d, d, bias=False) for k in keys})
+            self.raw_P_edge = nn.ParameterDict(
+                {k: nn.Parameter(torch.zeros(d)) for k in keys}
+            )
+        else:
+            raise ValueError(f"unknown edge_transform_mode {edge_transform_mode}")
 
         # Content scoring projections
         self.query_lin = nn.ModuleList([nn.Linear(d, d, bias=False) for _ in range(R)])
-        self.key_lin = nn.ModuleDict(
-            {k: nn.Linear(d, d, bias=False) for k in self.W_edge.keys()}
-        )
-
-        # Edge precision parameters (diag)
-        self.raw_P_edge = nn.ParameterDict(
-            {k: nn.Parameter(torch.zeros(d)) for k in self.W_edge.keys()}
-        )
 
         # Storage for last routing weights (for interpretability)
         self.last_weights: Dict[str, float] = {}
@@ -152,25 +180,20 @@ class Router(nn.Module):
         nn.init.normal_(self.beta_sin, std=0.01)
         self.fb_scale = 1.0 / math.sqrt(m_reg)
 
-    def messages(
+    def _messages_loop(
         self, H: torch.Tensor, reg_mask_prev: torch.Tensor, reg_coords: torch.Tensor
     ) -> torch.Tensor:
-        """Aggregate messages from previously active neighbors.
-
-        H: [R,d], reg_mask_prev: [R] bool, reg_coords: [R,2]
-        Returns M: [R,d]
-        """
+        """Original loop-based router (fallback when vectorization disabled)."""
         device = H.device
         M = torch.zeros(self.R, self.d, device=device)
         self.last_weights = {}
-        # Prepare coordinate tensors for bias
-        P = reg_coords.to(H.dtype).to(device).unsqueeze(0)  # [1,R,2]
+        P = reg_coords.to(H.dtype).to(device).unsqueeze(0)
         for r in range(self.R):
             acc = torch.zeros(self.d, device=device)
-            msgs = []
-            scores = []
-            robust = []
-            edge_keys = []
+            msgs: List[torch.Tensor] = []
+            scores: List[torch.Tensor] = []
+            robust: List[torch.Tensor] = []
+            edge_keys: List[str] = []
             q_r = None
             if self.enable_precision_routed_messages:
                 q_r = self.query_lin[r](H[r])
@@ -179,7 +202,6 @@ class Router(nn.Module):
                     continue
                 edge_key = f"{s}->{r}"
                 msg = self.W_edge[edge_key](H[s])
-                # Relative Fourier bias b(Δcoords) (scalar per edge)
                 b = relative_fourier_bias(
                     P[:, r : r + 1, :],
                     P[:, s : s + 1, :],
@@ -225,3 +247,104 @@ class Router(nn.Module):
             self.last_weight_mean = 0.0
             self.last_weight_entropy = 0.0
         return M
+
+    def aggregate(
+        self, H: torch.Tensor, reg_mask_prev: torch.Tensor, reg_coords: torch.Tensor
+    ) -> torch.Tensor:
+        """Vectorized message aggregation over active edges."""
+        device = H.device
+        src_idx = self.src_idx
+        dst_idx = self.dst_idx
+        edge_mask = reg_mask_prev[src_idx]
+        if not bool(edge_mask.any()):
+            return torch.zeros(self.R, self.d, device=device)
+        src_idx = src_idx[edge_mask]
+        dst_idx = dst_idx[edge_mask]
+        keys = [
+            self.edge_keys[i]
+            for i in torch.nonzero(edge_mask, as_tuple=False).flatten().tolist()
+        ]
+        H_src = H[src_idx]
+        H_dst = H[dst_idx]
+
+        # Message transforms
+        if self.edge_transform_mode == "per_edge":
+            W = torch.stack([self.W_edge[k].weight for k in keys])
+            msg = torch.bmm(W, H_src.unsqueeze(-1)).squeeze(-1)
+        elif self.edge_transform_mode == "by_direction":
+            dirs = self._edge_directions(reg_coords[src_idx], reg_coords[dst_idx])
+            W = torch.stack([self.W_dir[i].weight for i in dirs.tolist()])
+            msg = torch.bmm(W, H_src.unsqueeze(-1)).squeeze(-1)
+        else:  # factorized
+            Vh = self.V(H_src)
+            w = torch.stack([self.w_edge[k] for k in keys])
+            msg = self.U(Vh * w)
+
+        # Relative Fourier bias
+        if self.fb_alpha != 0.0:
+            delta = reg_coords[dst_idx] - reg_coords[src_idx]
+            S = delta @ self.W_reg.T
+            b = (torch.cos(S) * self.beta_cos + torch.sin(S) * self.beta_sin).sum(
+                -1
+            ) * self.fb_scale
+            msg = msg * (1.0 + self.fb_alpha * b).unsqueeze(-1)
+
+        if self.enable_precision_routed_messages:
+            q = torch.stack([self.query_lin[r](H[r]) for r in range(self.R)])
+            if self.edge_transform_mode == "by_direction":
+                K = torch.bmm(
+                    torch.stack([self.key_lin_dir[i].weight for i in dirs.tolist()]),
+                    H_src.unsqueeze(-1),
+                ).squeeze(-1)
+                P_edge = F.softplus(
+                    torch.stack([self.raw_P_dir[i] for i in dirs.tolist()])
+                )
+            else:
+                K = torch.bmm(
+                    torch.stack([self.key_lin[k].weight for k in keys]),
+                    H_src.unsqueeze(-1),
+                ).squeeze(-1)
+                P_edge = F.softplus(torch.stack([self.raw_P_edge[k] for k in keys]))
+            scores = (q[dst_idx] * K).sum(-1) / math.sqrt(self.d)
+            resid = msg - H_dst
+            mah = (resid.pow(2) * P_edge).sum(-1).clamp_max(MAX_EXP / 0.5)
+            logw = scores - 0.5 * mah
+            max_logw = torch.full((self.R,), -float("inf"), device=device)
+            max_logw.scatter_reduce_(0, dst_idx, logw, reduce="amax")
+            exp_sum = torch.zeros(self.R, device=device)
+            exp_sum.scatter_add_(0, dst_idx, torch.exp(logw - max_logw[dst_idx]))
+            logZ = max_logw + exp_sum.clamp_min(EPS_DIV).log()
+            w = torch.exp(logw - logZ[dst_idx])
+            self.last_weights = {k: float(wi.detach()) for k, wi in zip(keys, w)}
+        else:
+            w = torch.ones(len(src_idx), device=device)
+            self.last_weights = {}
+
+        M = torch.zeros(self.R, self.d, device=device)
+        M.index_add_(0, dst_idx, w.unsqueeze(-1) * msg)
+
+        if self.enable_precision_routed_messages and len(self.last_weights) > 0:
+            w_t = torch.tensor(list(self.last_weights.values()), device=device)
+            self.last_weight_mean = float(w_t.mean().item())
+            Z = w_t.sum().clamp_min(EPS_DIV)
+            p = w_t / Z
+            self.last_weight_entropy = float((-(p + EPS_LOG).log() * p).sum().item())
+        else:
+            self.last_weight_mean = 0.0
+            self.last_weight_entropy = 0.0
+        return M
+
+    def messages(
+        self, H: torch.Tensor, reg_mask_prev: torch.Tensor, reg_coords: torch.Tensor
+    ) -> torch.Tensor:
+        if self.vectorized:
+            return self.aggregate(H, reg_mask_prev, reg_coords)
+        return self._messages_loop(H, reg_mask_prev, reg_coords)
+
+    @staticmethod
+    def _edge_directions(src: torch.Tensor, dst: torch.Tensor) -> torch.Tensor:
+        """Map axial coordinate differences to one of six hex directions."""
+        diff = dst - src
+        dirs = diff.new_tensor([[1, 0], [1, -1], [0, -1], [-1, 0], [-1, 1], [0, 1]])
+        eq = (diff.unsqueeze(1) == dirs.unsqueeze(0)).all(-1)
+        return eq.float().argmax(-1).long()

--- a/ironcortex/model.py
+++ b/ironcortex/model.py
@@ -71,6 +71,8 @@ class CortexReasoner(nn.Module):
             self.d,
             self.R,
             enable_precision_routed_messages=cfg.enable_precision_routed_messages,
+            vectorized=cfg.router_vectorized,
+            edge_transform_mode=cfg.edge_transform_mode,
         )
 
         # Heads & workspace


### PR DESCRIPTION
## Summary
- Vectorize Router message aggregation with scatter-add and fused robust weighting
- Support per-edge, by-direction, and factorized transform modes plus config flags
- Wire new router options into model and mark Milestone 2 complete

## Testing
- `black ironcortex/config.py ironcortex/gate.py ironcortex/model.py`
- `ruff check ironcortex/config.py ironcortex/gate.py ironcortex/model.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68c0b10738188325aa4fd452bff14246