### PR TITLE
Implement adaptive filter milestone

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -82,21 +82,21 @@ Objective: Replace nested loops with batched message passing; fuse robust weight
 ### Rollback
 - Keep old loop under CFG.router_vectorized=False.
 
-## Milestone 3 — Adaptive Filter Dynamics: Streamline & Stabilize
+## Milestone 3 — Adaptive Filter Dynamics: Streamline & Stabilize ✅
 
 Objective: Simplify Kalman‑like updates; support dt>1 fast‑forward; limit parameter explosion.
 
 ### Tasks
-- Fast‑forward prior
+- [x] Fast‑forward prior
   - RG: RWKVRegionCell, state_num/state_den, dt
   - Implement fast_forward(dt) that updates mean & variance with decay = exp(decay_vec*dt); reuses same function for dt=1.
-- Scalar vs. vector noise options
+- [x] Scalar vs. vector noise options
   - Add CFG.afd_noise_mode ∈ {'scalar','vector'}; default 'scalar' for stability.
   - If scalar: process_noise and obs_noise are scalars per region or per head.
-- Gain computation
+- [x] Gain computation
   - Keep obs_var = exp(-k)*obs_noise + EPS_DIV.
   - Clamp gain to [0, 1]; avoid exact 0 or 1.
-- Predictive trace simplification
+- [x] Predictive trace simplification
   - RG: pred or predictive buffer in region cell
   - Ablation switch: CFG.use_predictive_trace. If False, remove predictive accumulation and rely on prior variance growth when inactive.
 

--- a/ironcortex/config.py
+++ b/ironcortex/config.py
@@ -17,6 +17,8 @@ class CortexConfig:
     enable_adaptive_filter_dynamics: bool = False
     enable_precision_routed_messages: bool = False
     enable_radial_tangential_updates: bool = False
+    afd_noise_mode: str = "scalar"
+    use_predictive_trace: bool = True
     enable_afa_attention: bool = False
     enable_ff_energy_alignment: bool = False
     router_vectorized: bool = True

--- a/ironcortex/model.py
+++ b/ironcortex/model.py
@@ -59,6 +59,8 @@ class CortexReasoner(nn.Module):
                     init_decay=cfg.init_decay,
                     enable_adaptive_filter_dynamics=cfg.enable_adaptive_filter_dynamics,
                     enable_radial_tangential_updates=cfg.enable_radial_tangential_updates,
+                    afd_noise_mode=cfg.afd_noise_mode,
+                    use_predictive_trace=cfg.use_predictive_trace,
                 )
                 for _ in range(self.R)
             ]
@@ -201,7 +203,8 @@ class CortexReasoner(nn.Module):
         for r in range(self.R):
             if not bool(reg_mask[r]):
                 # Update predictive trace from messages but skip actual update
-                self.regions[r].predict(M[r])
+                if self.cfg.use_predictive_trace:
+                    self.regions[r].predict(M[r])
                 self.regions[r].skip()
                 continue
             sensor_or_zero = (


### PR DESCRIPTION
## Summary
- add `afd_noise_mode` and `use_predictive_trace` config flags
- streamline RWKVRegionCell with fast-forward, scalar noise, gain clamp, and optional predictive trace
- gate predictive trace usage in CortexReasoner and mark milestone 3 tasks complete

## Testing
- `ruff check ironcortex/config.py ironcortex/model.py ironcortex/region.py tests/test_rwkv_region.py`
- `black ironcortex/config.py ironcortex/model.py ironcortex/region.py tests/test_rwkv_region.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_68c1bdc441988325b72be49c354bf30c