### PR TITLE
feat: cache AFA kernels and add robust weighting

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -131,15 +131,15 @@ Objective: Reduce redundancy; keep one smoothing mechanism on the radius.
 Objective: Replace O(T²) attention with convolutional/state‑space AFA.
 
 ### Tasks
-- Kernel builder & cache
+- [x] Kernel builder & cache
   - RG: AdaptiveFilterAttention, pairwise_precision, forward
   - Implement build_time_kernels(T) → returns lag kernels for e^{AΔtτ}; cache by (T, α, ω).
-- Depthwise convolution path
+- [ ] Depthwise convolution path
   - Convolve K or V along time per head with the kernel (FFT or causal 1D convolution).
   - Replace explicit T×T weight matrix with kernelized propagation + local normalization.
-- Robust weighting
+- [x] Robust weighting
   - Optionally compute residual‑based scalars per lag (precomputed pairwise_precision(τ)), multiply into kernel before convolution.
-- Fallback & parity
+- [ ] Fallback & parity
   - If T <= T_small or CFG.debug_exact, fall back to exact dot‑product path.
   - Unit test: with α=0, σ=0 → outputs match dot‑product attention (±1e‑4).
 


### PR DESCRIPTION
## Summary
- cache adaptive filter attention time-decay kernels keyed by sequence length and parameters
- add pairwise precision weighting into AFA decay
- document Milestone 5 progress in TODO

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch numpy matplotlib` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c450a26c832582d2209b11fc378a