### PR TITLE
Implement KWTA scheduling and soft gating

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -193,12 +193,12 @@ Objective: Simplify training path; reduce branching overhead.
 Objective: Reduce redundancy between region gating and KWTA.
 
 ### Tasks
-- KWTA schedule & soft mode
+- [x] KWTA schedule & soft mode
   - Add kwta_k_schedule: start with larger k (less sparse), anneal to target k.
   - kwta_soft_mode=True uses a soft-threshold approximation during warmup (e.g., top‑k mask replaced by sigmoid gate with temperature anneal).
-- Ablate dual sparsity
+- [x] Ablate dual sparsity
   - Experiment flag CFG.disable_kwta_during_gating to rely on gating only; or reduce region gating aggressiveness when KWTA is strict.
-- Vectorized KWTA
+- [x] Vectorized KWTA
   - Implement row‑wise top‑k on [R,d] in one call instead of loop per region.
 
 ### Acceptance

--- a/ironcortex/config.py
+++ b/ironcortex/config.py
@@ -31,6 +31,13 @@ class CortexConfig:
     surprise_lambda_schedule: int = 0
     tau_kappa: float = 0.0
     tau_target_prec: float = 1.0
+    # KWTA sparsity controls
+    kwta_k: int = 0  # 0 -> use d//8
+    kwta_k_start: int = 0  # 0 -> same as kwta_k
+    kwta_k_schedule: int = 0
+    kwta_soft_mode: bool = False
+    kwta_soft_temp: float = 1.0
+    disable_kwta_during_gating: bool = False
     # Attention debugging: force exact path or threshold for kernel path
     debug_exact: bool = False
     afa_exact_threshold: int = 64

--- a/ironcortex/model.py
+++ b/ironcortex/model.py
@@ -61,6 +61,12 @@ class CortexReasoner(nn.Module):
                     enable_radial_tangential_updates=cfg.enable_radial_tangential_updates,
                     afd_noise_mode=cfg.afd_noise_mode,
                     use_predictive_trace=cfg.use_predictive_trace,
+                    kwta_k=cfg.kwta_k,
+                    kwta_k_start=cfg.kwta_k_start,
+                    kwta_k_schedule=cfg.kwta_k_schedule,
+                    kwta_soft_mode=cfg.kwta_soft_mode,
+                    kwta_soft_temp=cfg.kwta_soft_temp,
+                    disable_kwta=cfg.disable_kwta_during_gating,
                 )
                 for _ in range(self.R)
             ]

--- a/ironcortex/training.py
+++ b/ironcortex/training.py
@@ -54,6 +54,8 @@ def train_step(
 
     step = getattr(model, "_train_step", 0) + 1
     model._train_step = step
+    for reg in model.regions:
+        reg.global_step = step
     if model.cfg.enable_ff_energy_alignment:
         if model.cfg.surprise_lambda_schedule > 0:
             warm = min(1.0, step / model.cfg.surprise_lambda_schedule)

--- a/tests/test_kwta.py
+++ b/tests/test_kwta.py
@@ -1,0 +1,38 @@
+import torch
+from ironcortex.utils import KWTA
+from ironcortex.region import RWKVRegionCell
+
+
+def test_kwta_vectorized_soft():
+    x = torch.tensor([[3.0, 2.0, 1.0], [1.0, -2.0, 0.5]])
+    y_hard = KWTA(x, k=1)
+    assert y_hard.nonzero().shape[0] == 2
+    y_soft = KWTA(x, k=1, soft=True, temp=1.0)
+    assert y_soft.shape == x.shape
+    assert y_soft.abs().sum() > y_hard.abs().sum()
+
+
+def test_region_kwta_schedule_and_disable():
+    torch.manual_seed(0)
+    d = 4
+    cell = RWKVRegionCell(
+        d,
+        m_time_pairs=0,
+        kwta_k=1,
+        kwta_k_start=4,
+        kwta_k_schedule=10,
+        kwta_soft_mode=True,
+        kwta_soft_temp=5.0,
+    )
+    x = torch.randn(d)
+    cell.global_step = 0
+    h0 = cell.step(x, 0.0)
+    assert h0.nonzero().numel() > 1
+    cell.global_step = 10
+    h1 = cell.step(x, 0.0)
+    assert h1.nonzero().shape[0] == 1
+    cell_disable = RWKVRegionCell(d, m_time_pairs=0, disable_kwta=True)
+    x2 = torch.randn(d)
+    cell_disable.global_step = 10
+    h_disable = cell_disable.step(x2, 0.0)
+    assert h_disable.nonzero().shape[0] == d


### PR DESCRIPTION
## Summary
- add configurable KWTA schedule with optional soft gating warmup
- expose KWTA sparsity options in `CortexConfig` and region cells
- allow disabling KWTA during gating and update milestone checklist

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch numpy matplotlib` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_68c1eaf8e6308325a3973a6a88bb8eee