### PR TITLE
fix region imports causing demo import error

### DIFF
--- a/ironcortex/region.py
+++ b/ironcortex/region.py
@@ -3,9 +3,9 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from .utils import RMSNorm, KWTA, init_weights
-from .iron_rope import rope_rotate_pairs, make_freq_bank
-from .constants import EPS_DIV, MAX_EXP, MAX_NOISE
+from ironcortex.utils import RMSNorm, KWTA, init_weights
+from ironcortex.iron_rope import rope_rotate_pairs, make_freq_bank
+from ironcortex.constants import EPS_DIV, MAX_EXP, MAX_NOISE
 
 # 5) RWKV Region Cell (with Δt skip + time rotation on v)
 # ==========================================================


### PR DESCRIPTION
## Summary
- use absolute imports in `ironcortex.region` to avoid relative import errors when running demos

## Testing
- `black ironcortex/region.py`
- `ruff check ironcortex/region.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68c1f547872c832592788139dee4d47a