### PR TITLE
Skip radial direction assert when norm is tiny

### DIFF
--- a/ironcortex/region.py
+++ b/ironcortex/region.py
@@ -219,8 +219,9 @@ class RWKVRegionCell(nn.Module):
             norm = y.norm(2, dim=-1, keepdim=True).clamp_min(EPS_DIV)
             dir = y / norm
             if __debug__:
-                dir_norm = dir.norm().detach()
-                assert abs(dir_norm.item() - 1.0) < 1e-3
+                dir_norm = dir.norm().detach().item()
+                if norm.item() > EPS_DIV:
+                    assert abs(dir_norm - 1.0) < 1e-3
             self.last_dir = dir.detach()
             self.last_norm = norm.detach()
             h_dir = self.o_lin(dir)


### PR DESCRIPTION
## Summary
- avoid assertion failure in `RWKVRegionCell` when radial direction has zero norm

## Testing
- `black ironcortex/region.py`
- `ruff check .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68c1f63215a483259cc1ce7bb126a0ee