### PR TITLE
Ensure tiny Shakespeare demo uses 10M param model

### DIFF
--- a/train_tiny_shakespeare_10m.py
+++ b/train_tiny_shakespeare_10m.py
@@ -30,7 +30,7 @@ class _Args:
 def build_small_model(device: torch.device) -> CortexReasoner:
     """Builds a ~10M parameter model with all experimental flags enabled."""
     cfg = CortexConfig(
-        R=20,
+        R=10,
         d=256,
         V=256,
         K_inner=8,
@@ -44,6 +44,7 @@ def build_small_model(device: torch.device) -> CortexReasoner:
         enable_ff_energy_alignment=True,
         enable_energy_verifier=True,
         enable_forward_forward=True,
+        debug_metrics_every_n_steps=2,
     )
     neighbors = hex_neighbors(cfg.R)
     reg_coords = hex_axial_coords(cfg.R)


### PR DESCRIPTION
## Summary
- shrink tiny Shakespeare demo to 10 regions for ~10M params
- emit debug telemetry every 2 steps via config flag

## Testing
- `black train_tiny_shakespeare_10m.py`
- `ruff check train_tiny_shakespeare_10m.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68c1fb21ad448325a4ccd0a75a8fe7eb